### PR TITLE
Fix config location on Linux/Mac

### DIFF
--- a/Neurotrauma/Lua/Scripts/configdata.lua
+++ b/Neurotrauma/Lua/Scripts/configdata.lua
@@ -1,7 +1,7 @@
 NTConfig = {Entries={},Expansions={}} -- contains all config options, their default, type, valid ranges, difficulty influence
 
-local configDirectoryPath = Game.SaveFolder.."\\ModConfigs"
-local configFilePath = configDirectoryPath.."\\Neurotrauma.json"
+local configDirectoryPath = Game.SaveFolder.."/ModConfigs"
+local configFilePath = configDirectoryPath.."/Neurotrauma.json"
 
 -- this is the function that gets used in other mods to add their own settings to the config
 function NTConfig.AddConfigOptions(expansion)


### PR DESCRIPTION
The use of backslash as the path separator results in literal backslashes on Linux and Mac.
Windows supports both `/` and `\`.