### PR TITLE
Cybernetics Compatibility fixes

### DIFF
--- a/Neurotrauma/Lua/Scripts/Server/humanupdate.lua
+++ b/Neurotrauma/Lua/Scripts/Server/humanupdate.lua
@@ -336,7 +336,7 @@ NT.Afflictions = {
             (1-math.min(1,c.afflictions.cardiacarrest.strength)) *              -- none if cardiac arrest
             NTC.GetMultiplier(c.character,"bloodpressure")
             
-        local bloodpressurelerp = 0.2
+        local bloodpressurelerp = 0.2 * NTC.GetMultiplier(c.character,"bloodpressurerate")
         -- adjust three times slower to heightened blood pressure
         if(desiredbloodpressure>c.afflictions.bloodpressure.strength) then bloodpressurelerp = bloodpressurelerp/3 end
         c.afflictions.bloodpressure.strength = HF.Clamp(HF.Round(

--- a/Neurotrauma/Lua/Scripts/Server/items.lua
+++ b/Neurotrauma/Lua/Scripts/Server/items.lua
@@ -310,7 +310,7 @@ NT.ItemMethods.suture = function(item, usingCharacter, targetCharacter, limb)
                 limbtoitem[LimbType.LeftArm] = "larm"
                 if limbtoitem[limbtype] ~= nil then
                     HF.GiveItem(usingCharacter,limbtoitem[limbtype])
-                    if NTSP ~= nil and NTConfig.Get("NTSP_enableSurgerySkill",true) then HF.GiveSkill(usingCharacter,"surgery",0.5) end
+                    HF.GiveSurgerySkill(usingCharacter,0.5)
                 end
             end
         end
@@ -320,22 +320,14 @@ NT.ItemMethods.suture = function(item, usingCharacter, targetCharacter, limb)
             if HF.HasAfflictionLimb(targetCharacter,affidentifier,limbtype) then
                 HF.SetAfflictionLimb(targetCharacter,affidentifier,limbtype,0,usingCharacter)
 
-                if NTSP ~= nil and NTConfig.Get("NTSP_enableSurgerySkill",true) then 
-                    HF.GiveSkill(usingCharacter,"surgery",skillgain)
-                else 
-                    HF.GiveSkill(usingCharacter,"medical",skillgain/4)
-                end
+                HF.GiveSurgerySkill(usingCharacter,skillgain)
             end
         end
         local function removeAfflictionNonLimbSpecificPlusGainSkill(affidentifier,skillgain)
             if HF.HasAffliction(targetCharacter,affidentifier) then
                 HF.SetAffliction(targetCharacter,affidentifier,0,usingCharacter)
 
-                if NTSP ~= nil and NTConfig.Get("NTSP_enableSurgerySkill",true) then 
-                    HF.GiveSkill(usingCharacter,"surgery",skillgain)
-                else 
-                    HF.GiveSkill(usingCharacter,"medical",skillgain/4)
-                end
+                HF.GiveSurgerySkill(usingCharacter,skillgain)
             end
         end
 

--- a/Neurotrauma/Lua/Scripts/Server/items.lua
+++ b/Neurotrauma/Lua/Scripts/Server/items.lua
@@ -1243,18 +1243,21 @@ local function InfuseBloodpack(item, packtype, usingCharacter, targetCharacter, 
     -- determine compatibility
     local packhasantibodyA = string.find(packtype, "a")
     local packhasantibodyB = string.find(packtype, "b")
+    local packhasantibodyC = string.find(packtype, "c") -- NT Cybernetics cyberblood
     local packhasantibodyRh = string.find(packtype, "plus")
 
     local targettype = NT.GetBloodtype(targetCharacter)
 
     local targethasantibodyA = string.find(targettype, "a")
     local targethasantibodyB = string.find(targettype, "b")
+    local targethasantibodyC = string.find(targettype, "c")
     local targethasantibodyRh = string.find(targettype, "plus")
 
     local compatible = 
     (targethasantibodyRh or not packhasantibodyRh) and
     (targethasantibodyA or not packhasantibodyA) and
-    (targethasantibodyB or not packhasantibodyB)
+    (targethasantibodyB or not packhasantibodyB) and
+    (targethasantibodyC or not packhasantibodyC)
     -- TODO: give always true to team of bots on enemy submarines for future medic AI logic
 
     local bloodloss = HF.GetAfflictionStrength(targetCharacter,"bloodloss",0)

--- a/Neurotrauma/Lua/Scripts/helperfunctions.lua
+++ b/Neurotrauma/Lua/Scripts/helperfunctions.lua
@@ -472,6 +472,14 @@ function HF.GiveSkill(character,skilltype,amount)
     end
 end
 
+function HF.GiveSurgerySkill(character, amount)
+    if NTSP ~= nil and NTConfig.Get("NTSP_enableSurgerySkill",true) then
+        HF.GiveSkill(character,"surgery",amount)
+    else
+        HF.GiveSkill(character,"medical",amount/4)
+    end
+end
+
 -- amount = vitality healed
 function HF.GiveSkillScaled(character,skilltype,amount)
     if character ~= nil and character.Info ~= nil then

--- a/Neurotrauma/Xml/Afflictions.xml
+++ b/Neurotrauma/Xml/Afflictions.xml
@@ -3680,9 +3680,18 @@ thats what the vomiting symptom is for -->
     limbspecific="false"
     showiconthreshold="10"
     maxstrength="200">
-    <Effect minstrength="0" maxstrength="200"
-	    resistancefor="damage"
+    <Effect minstrength="0" maxstrength="5"
+      resistancefor="damage"
       minresistance="0"
+      maxresistance="0.025"
+      strengthchange="-0.3">
+      <StatusEffect target="Character">
+        <ReduceAffliction type="pain" amount="5" />
+      </StatusEffect>
+    </Effect>
+    <Effect minstrength="5" maxstrength="200"
+      resistancefor="damage"
+      minresistance="0.025"
       maxresistance="0.5"
       minscreendistort="0.0"
       maxscreendistort="0.0"

--- a/Neurotrauma/Xml/items.xml
+++ b/Neurotrauma/Xml/items.xml
@@ -2267,7 +2267,7 @@
 
   <!-- Organ transplants
   Thank you for not letting me spawn in items with specific conditions, Barotrauma -->
-  <Item name="" identifier="livertransplant" description="" category="Medical" scale="0.4" useinhealthinterface="True" impactsoundtag="impact_soft" cargocontaineridentifier="organcrate" impacttolerance="5.5" Tags="smallitem,organ,petfood1,petfood2,petfood3">
+  <Item name="" identifier="livertransplant" description="" category="Medical" scale="0.4" useinhealthinterface="True" impactsoundtag="impact_soft" cargocontaineridentifier="organcrate" impacttolerance="5.5" Tags="smallitem,organ,liver,petfood1,petfood2,petfood3">
     <Price baseprice="1000" soldbydefault="false">
       <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
     </Price>
@@ -2310,7 +2310,7 @@
     </Price>
   </Item>
 
-  <Item name="" identifier="lungtransplant" description="" category="Medical" scale="0.4" useinhealthinterface="True" impactsoundtag="impact_soft" cargocontaineridentifier="organcrate" impacttolerance="5.5" Tags="smallitem,organ,petfood1,petfood2,petfood3">
+  <Item name="" identifier="lungtransplant" description="" category="Medical" scale="0.4" useinhealthinterface="True" impactsoundtag="impact_soft" cargocontaineridentifier="organcrate" impacttolerance="5.5" Tags="smallitem,organ,lung,petfood1,petfood2,petfood3">
     <Price baseprice="2000" soldbydefault="false">
       <Price locationtype="research" multiplier="1" sold="true" minavailable="2"/>
     </Price>
@@ -2353,7 +2353,7 @@
     </Price>
   </Item>
 
-  <Item name="" identifier="kidneytransplant" description="" category="Medical" scale="0.4" useinhealthinterface="True" impactsoundtag="impact_soft" cargocontaineridentifier="organcrate" impacttolerance="5.5" Tags="smallitem,organ,petfood1,petfood2,petfood3">
+  <Item name="" identifier="kidneytransplant" description="" category="Medical" scale="0.4" useinhealthinterface="True" impactsoundtag="impact_soft" cargocontaineridentifier="organcrate" impacttolerance="5.5" Tags="smallitem,organ,kidney,petfood1,petfood2,petfood3">
     <Price baseprice="400" soldbydefault="false">
       <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="2"/>
     </Price>
@@ -2396,7 +2396,7 @@
     </Price>
   </Item>
 
-  <Item name="" identifier="hearttransplant" description="" category="Medical" scale="0.4" useinhealthinterface="True" impactsoundtag="impact_soft" cargocontaineridentifier="organcrate" impacttolerance="5.5" Tags="smallitem,organ,petfood1,petfood2,petfood3">
+  <Item name="" identifier="hearttransplant" description="" category="Medical" scale="0.4" useinhealthinterface="True" impactsoundtag="impact_soft" cargocontaineridentifier="organcrate" impacttolerance="5.5" Tags="smallitem,organ,heart,petfood1,petfood2,petfood3">
     <Price baseprice="4000" soldbydefault="false">
       <Price locationtype="research" multiplier="1" sold="true" minavailable="2"/>
     </Price>
@@ -2439,7 +2439,7 @@
     </Price>
   </Item>
 
-  <Item name="" identifier="braintransplant" description="" category="Medical" scale="0.3" useinhealthinterface="True" impactsoundtag="impact_soft" cargocontaineridentifier="organcrate" impacttolerance="1.5" Tags="smallitem,organ,petfood1,petfood2,petfood3,braintransplant">
+  <Item name="" identifier="braintransplant" description="" category="Medical" scale="0.3" useinhealthinterface="True" impactsoundtag="impact_soft" cargocontaineridentifier="organcrate" impacttolerance="1.5" Tags="smallitem,organ,brain,petfood1,petfood2,petfood3,braintransplant">
     <Price baseprice="0" soldbydefault="false">
       <Price storeidentifier="merchantmedical" sold="false"/>
     </Price>


### PR DESCRIPTION
As part of working on Cyberorgans (which I would like to eventually merge into the main NT Cybernetics folder, once the bugs are worked out and the other PR's are closed), I ran into a few changes best made in the base Neurotrauma mod:

* ~~[Organs: treat medfab as refridgerated (so cyberorgans are craftable without decaying mid-craft)](https://github.com/OlegBSTU/Neurotrauma/commit/326d3f86438f1e1829f38c36cca81a2175a7353f)~~
* [Organs: add organ-specific tags so the transplant_q1's can be interchangable in crafting recipes](https://github.com/OlegBSTU/Neurotrauma/pull/18/commits/3d7241da6c17bf5a0521ab282d7d943c3bb0fc30)
* [Fixed Amputation Surgery not granting medical skill](https://github.com/OlegBSTU/Neurotrauma/commit/69c45fe6fdb3e2e2fdad745aa53ebe85bc63bbc5)
* [Add Cyberblood type 'c'](https://github.com/OlegBSTU/Neurotrauma/commit/5c1d3404f70b84825a1aa5f028942855e6ac6b33), all this adds is theoretical support for a "c" antigen that works identically to how "a" and "b" do, but with NT Cybernetics the Cyberkidney gives you type "C" blood (secretly `abcplus`) which is thus maximum-selfish
* [Analgesia: Disable visual effects at < 5%](https://github.com/OlegBSTU/Neurotrauma/commit/7008d964f8dde3e818bf6dc842a016d4aab8cebb), both because they start off rather strong for having a pretty weak analgesic in ya, and I want the Cyberbrain to perpetually grant a very mild analgesic effect ("pain editing") to make surgery easier on Cyborgs, but the visuals are pretty obnoxious