### PR TITLE
Organs shouldn't degrade while crafting

### DIFF
--- a/Neurotrauma/Xml/items.xml
+++ b/Neurotrauma/Xml/items.xml
@@ -2283,6 +2283,9 @@
       <StatusEffect type="Always" target="This" condition="-0.5">
         <Conditional hastag="neq refrigerated" targetcontainer="true" />
       </StatusEffect>
+	  <StatusEffect type="Always" target="This" condition="0.5" conditionalComparison="And" >
+        <Conditional hastag="eq medicalfabricator" Locked="eq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
+      </StatusEffect>
       <StatusEffect type="OnContained" target="This" condition="0.1" comparison="and">
         <Conditional condition="gte 90" />
         <Conditional hastag="refrigerated" targetcontainer="true" />
@@ -2324,6 +2327,9 @@
       <!-- making the organ go kaputt if left outside of refrigeration -->
       <StatusEffect type="Always" target="This" condition="-0.5">
         <Conditional hastag="neq refrigerated" targetcontainer="true" />
+      </StatusEffect>
+	  <StatusEffect type="Always" target="This" condition="0.5" conditionalComparison="And" >
+        <Conditional hastag="eq medicalfabricator" Locked="eq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
       </StatusEffect>
       <StatusEffect type="OnContained" target="This" condition="0.1" comparison="and">
         <Conditional condition="gte 90" />
@@ -2367,6 +2373,9 @@
       <StatusEffect type="Always" target="This" condition="-0.5">
         <Conditional hastag="neq refrigerated" targetcontainer="true" />
       </StatusEffect>
+	  <StatusEffect type="Always" target="This" condition="0.5" conditionalComparison="And" >
+        <Conditional hastag="eq medicalfabricator" Locked="eq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
+      </StatusEffect>
       <StatusEffect type="OnContained" target="This" condition="0.1" comparison="and">
         <Conditional condition="gte 90" />
         <Conditional hastag="refrigerated" targetcontainer="true" />
@@ -2408,6 +2417,9 @@
       <!-- making the organ go kaputt if left outside of refrigeration -->
       <StatusEffect type="Always" target="This" condition="-0.5">
         <Conditional hastag="neq refrigerated" targetcontainer="true" />
+      </StatusEffect>
+	  <StatusEffect type="Always" target="This" condition="0.5" conditionalComparison="And" >
+        <Conditional hastag="eq medicalfabricator" Locked="eq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
       </StatusEffect>
       <StatusEffect type="OnContained" target="This" condition="0.1" comparison="and">
         <Conditional condition="gte 90" />
@@ -2452,6 +2464,9 @@
       <StatusEffect type="Always" target="This" condition="-2" comparison="and">
         <Conditional hastag="neq refrigerated" targetcontainer="true" />
         <Conditional hastag="neq braincontainer" targetcontainer="true" />
+      </StatusEffect>
+	  <StatusEffect type="Always" target="This" condition="2" conditionalComparison="And" >
+        <Conditional hastag="eq medicalfabricator" Locked="eq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
       </StatusEffect>
       <StatusEffect type="OnContained" target="This" condition="-0.2" comparison="and">
         <Conditional hastag="refrigerated" targetcontainer="true" />

--- a/Neurotrauma/Xml/items.xml
+++ b/Neurotrauma/Xml/items.xml
@@ -2086,7 +2086,7 @@
                 <Sound file="%ModDir%/Sound/severed.ogg" range="500"/>
             </StatusEffect>
           <!-- making the limb go kaputt if left outside of refrigeration -->
-          <StatusEffect type="Always" target="This" condition="-0.2">
+          <StatusEffect type="Always" target="This" condition="-0.2" conditionalComparison="And">
             <Conditional hastag="neq refrigerated" targetcontainer="true" />
 			<Conditional hastag="neq medicalfabricator" Locked="neq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
           </StatusEffect>
@@ -2119,7 +2119,7 @@
                 <Sound file="%ModDir%/Sound/severed.ogg" range="500"/>
             </StatusEffect>
           <!-- making the limb go kaputt if left outside of refrigeration -->
-          <StatusEffect type="Always" target="This" condition="-0.2">
+          <StatusEffect type="Always" target="This" condition="-0.2" conditionalComparison="And">
             <Conditional hastag="neq refrigerated" targetcontainer="true" />
 			<Conditional hastag="neq medicalfabricator" Locked="neq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
           </StatusEffect>
@@ -2152,7 +2152,7 @@
                 <Sound file="%ModDir%/Sound/severed.ogg" range="500"/>
             </StatusEffect>
           <!-- making the limb go kaputt if left outside of refrigeration -->
-          <StatusEffect type="Always" target="This" condition="-0.2">
+          <StatusEffect type="Always" target="This" condition="-0.2" conditionalComparison="And">
             <Conditional hastag="neq refrigerated" targetcontainer="true" />
 			<Conditional hastag="neq medicalfabricator" Locked="neq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
           </StatusEffect>
@@ -2185,7 +2185,7 @@
                 <Sound file="%ModDir%/Sound/severed.ogg" range="500"/>
             </StatusEffect>
           <!-- making the limb go kaputt if left outside of refrigeration -->
-          <StatusEffect type="Always" target="This" condition="-0.2">
+          <StatusEffect type="Always" target="This" condition="-0.2" conditionalComparison="And">
             <Conditional hastag="neq refrigerated" targetcontainer="true" />
 			<Conditional hastag="neq medicalfabricator" Locked="neq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
           </StatusEffect>
@@ -2284,7 +2284,7 @@
         <Remove />
       </StatusEffect>
       <!-- making the organ go kaputt if left outside of refrigeration -->
-      <StatusEffect type="Always" target="This" condition="-0.5">
+      <StatusEffect type="Always" target="This" condition="-0.5" conditionalComparison="And">
         <Conditional hastag="neq refrigerated" targetcontainer="true" />
 		<Conditional hastag="neq medicalfabricator" Locked="neq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
       </StatusEffect>
@@ -2327,7 +2327,7 @@
         <Remove />
       </StatusEffect>
       <!-- making the organ go kaputt if left outside of refrigeration -->
-      <StatusEffect type="Always" target="This" condition="-0.5">
+      <StatusEffect type="Always" target="This" condition="-0.5" conditionalComparison="And">
         <Conditional hastag="neq refrigerated" targetcontainer="true" />
 		<Conditional hastag="neq medicalfabricator" Locked="neq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
       </StatusEffect>
@@ -2370,7 +2370,7 @@
         <Remove />
       </StatusEffect>
       <!-- making the organ go kaputt if left outside of refrigeration -->
-      <StatusEffect type="Always" target="This" condition="-0.5">
+      <StatusEffect type="Always" target="This" condition="-0.5" conditionalComparison="And">
         <Conditional hastag="neq refrigerated" targetcontainer="true" />
 		<Conditional hastag="neq medicalfabricator" Locked="neq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
       </StatusEffect>
@@ -2413,7 +2413,7 @@
         <Remove />
       </StatusEffect>
       <!-- making the organ go kaputt if left outside of refrigeration -->
-      <StatusEffect type="Always" target="This" condition="-0.5">
+      <StatusEffect type="Always" target="This" condition="-0.5" conditionalComparison="And">
         <Conditional hastag="neq refrigerated" targetcontainer="true" />
 		<Conditional hastag="neq medicalfabricator" Locked="neq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
       </StatusEffect>

--- a/Neurotrauma/Xml/items.xml
+++ b/Neurotrauma/Xml/items.xml
@@ -2088,6 +2088,7 @@
           <!-- making the limb go kaputt if left outside of refrigeration -->
           <StatusEffect type="Always" target="This" condition="-0.2">
             <Conditional hastag="neq refrigerated" targetcontainer="true" />
+			<Conditional hastag="neq medicalfabricator" Locked="neq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
           </StatusEffect>
           <StatusEffect type="OnContained" target="This" condition="0.1" comparison="and">
             <Conditional condition="gte 95" />
@@ -2120,6 +2121,7 @@
           <!-- making the limb go kaputt if left outside of refrigeration -->
           <StatusEffect type="Always" target="This" condition="-0.2">
             <Conditional hastag="neq refrigerated" targetcontainer="true" />
+			<Conditional hastag="neq medicalfabricator" Locked="neq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
           </StatusEffect>
           <StatusEffect type="OnContained" target="This" condition="0.1" comparison="and">
             <Conditional condition="gte 95" />
@@ -2152,6 +2154,7 @@
           <!-- making the limb go kaputt if left outside of refrigeration -->
           <StatusEffect type="Always" target="This" condition="-0.2">
             <Conditional hastag="neq refrigerated" targetcontainer="true" />
+			<Conditional hastag="neq medicalfabricator" Locked="neq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
           </StatusEffect>
           <StatusEffect type="OnContained" target="This" condition="0.1" comparison="and">
             <Conditional condition="gte 95" />
@@ -2184,6 +2187,7 @@
           <!-- making the limb go kaputt if left outside of refrigeration -->
           <StatusEffect type="Always" target="This" condition="-0.2">
             <Conditional hastag="neq refrigerated" targetcontainer="true" />
+			<Conditional hastag="neq medicalfabricator" Locked="neq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
           </StatusEffect>
           <StatusEffect type="OnContained" target="This" condition="0.1" comparison="and">
             <Conditional condition="gte 95" />
@@ -2282,9 +2286,7 @@
       <!-- making the organ go kaputt if left outside of refrigeration -->
       <StatusEffect type="Always" target="This" condition="-0.5">
         <Conditional hastag="neq refrigerated" targetcontainer="true" />
-      </StatusEffect>
-	  <StatusEffect type="Always" target="This" condition="0.5" conditionalComparison="And" >
-        <Conditional hastag="eq medicalfabricator" Locked="eq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
+		<Conditional hastag="neq medicalfabricator" Locked="neq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
       </StatusEffect>
       <StatusEffect type="OnContained" target="This" condition="0.1" comparison="and">
         <Conditional condition="gte 90" />
@@ -2327,9 +2329,7 @@
       <!-- making the organ go kaputt if left outside of refrigeration -->
       <StatusEffect type="Always" target="This" condition="-0.5">
         <Conditional hastag="neq refrigerated" targetcontainer="true" />
-      </StatusEffect>
-	  <StatusEffect type="Always" target="This" condition="0.5" conditionalComparison="And" >
-        <Conditional hastag="eq medicalfabricator" Locked="eq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
+		<Conditional hastag="neq medicalfabricator" Locked="neq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
       </StatusEffect>
       <StatusEffect type="OnContained" target="This" condition="0.1" comparison="and">
         <Conditional condition="gte 90" />
@@ -2372,9 +2372,7 @@
       <!-- making the organ go kaputt if left outside of refrigeration -->
       <StatusEffect type="Always" target="This" condition="-0.5">
         <Conditional hastag="neq refrigerated" targetcontainer="true" />
-      </StatusEffect>
-	  <StatusEffect type="Always" target="This" condition="0.5" conditionalComparison="And" >
-        <Conditional hastag="eq medicalfabricator" Locked="eq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
+		<Conditional hastag="neq medicalfabricator" Locked="neq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
       </StatusEffect>
       <StatusEffect type="OnContained" target="This" condition="0.1" comparison="and">
         <Conditional condition="gte 90" />
@@ -2417,9 +2415,7 @@
       <!-- making the organ go kaputt if left outside of refrigeration -->
       <StatusEffect type="Always" target="This" condition="-0.5">
         <Conditional hastag="neq refrigerated" targetcontainer="true" />
-      </StatusEffect>
-	  <StatusEffect type="Always" target="This" condition="0.5" conditionalComparison="And" >
-        <Conditional hastag="eq medicalfabricator" Locked="eq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
+		<Conditional hastag="neq medicalfabricator" Locked="neq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
       </StatusEffect>
       <StatusEffect type="OnContained" target="This" condition="0.1" comparison="and">
         <Conditional condition="gte 90" />
@@ -2461,12 +2457,10 @@
         <Remove />
       </StatusEffect>
       <!-- making the organ go kaputt if left outside of refrigeration -->
-      <StatusEffect type="Always" target="This" condition="-2" comparison="and">
+      <StatusEffect type="Always" target="This" condition="-2" comparison="and" conditionalComparison="And">
         <Conditional hastag="neq refrigerated" targetcontainer="true" />
         <Conditional hastag="neq braincontainer" targetcontainer="true" />
-      </StatusEffect>
-	  <StatusEffect type="Always" target="This" condition="2" conditionalComparison="And" >
-        <Conditional hastag="eq medicalfabricator" Locked="eq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
+		<Conditional hastag="neq medicalfabricator" Locked="neq true" targetitemcomponent="ItemContainer" targetcontainer="true" />
       </StatusEffect>
       <StatusEffect type="OnContained" target="This" condition="-0.2" comparison="and">
         <Conditional hastag="refrigerated" targetcontainer="true" />


### PR DESCRIPTION
This PR makes it so that the organ transplant items to stop degrading while in crafting progression inside a medical fabricator.

This makes it easier for add-on modders to use organs in crafting recipes without having the need to overwrite them, which certainly will cause compatibility issues. (Ex: NT Lobotomy and NT Cybernetics Enhanced)
