### PR TITLE
Body/stasis bag dragging area effect fix

### DIFF
--- a/Neurotrauma/Lua/Scripts/Server/items.lua
+++ b/Neurotrauma/Lua/Scripts/Server/items.lua
@@ -1484,6 +1484,22 @@ NT.ItemStartsWithMethods.bloodpack = function(item, usingCharacter, targetCharac
     InfuseBloodpack(item,packtype,usingCharacter,targetCharacter,limb)
 end
 
+-- make it so that the person dragging the wearer of a body bag can drag fast
+-- fast dragging may start a little late
+Hook.Add("bodybag.dragfast", "bodybag.dragfast", function(effect, deltaTime, item, targets, worldPosition)
+    local target=nil
+	
+	for key in targets do
+		target=key
+	end
+	
+	if target==nil then return end
+
+	local dragger=target.SelectedBy
+	if dragger==nil then return end
+	HF.SetAffliction(dragger,"stretchers",100)
+end)
+
 -- this exists purely for NT metabolism
 Hook.Add("NT.RotOrgan", "NT.RotOrgan", function(effect, deltaTime, item, targets, worldPosition)
     if item then NT.RotOrgan(item) end

--- a/Neurotrauma/Xml/Afflictions.xml
+++ b/Neurotrauma/Xml/Afflictions.xml
@@ -1865,7 +1865,7 @@
   <Affliction name="" identifier="stretchers" isbuff="True" limbspecific="False" type="ambulance"
   showinhealthscannerthreshold="200" showiconthreshold="200" maxstrength="100"
     healableinmedicalclinic="false">
-    <Effect minstrength="0" maxstrength="100" strengthchange="-50">
+    <Effect minstrength="0" maxstrength="100" strengthchange="-100">
       <AbilityFlag flagtype="MoveNormallyWhileDragging" />
     </Effect>
     <icon texture="%ModDir%/Images/AfflictionIcons.png" sourcerect="0,256,128,128" color="139,60,42,255" origin="0,0" />

--- a/Neurotrauma/Xml/items.xml
+++ b/Neurotrauma/Xml/items.xml
@@ -1975,9 +1975,12 @@
       <StatusEffect type="OnWearing" target="Character" disabledeltatime="true" stackable="false" duration="1">
         <Affliction identifier="bodybagoverlay" amount="3"/>
       </StatusEffect>
-      <StatusEffect type="OnWearing" target="NearbyCharacters" range="100" stackable="true" setvalue="true">
+    <!--  <StatusEffect type="OnWearing" target="NearbyCharacters" range="100" stackable="true" setvalue="true">
         <Conditional ishuman="true"/>
         <Affliction identifier="stretchers" amount="100" />
+      </StatusEffect> -->
+      <StatusEffect type="OnWearing" target="Character" interval="0.25" disabledeltatime="true">
+        <LuaHook name="bodybag.dragfast" custom="Character" />
       </StatusEffect>
     </Wearable>
     <aitarget maxsightrange="50" />
@@ -2029,8 +2032,11 @@
         <Sound file="Content/Items/Diving/DivingSuitLoop1.ogg" range="500" />
         <Sound file="Content/Items/Diving/DivingSuitLoop2.ogg" range="500" />
       </StatusEffect>
-      <StatusEffect type="OnWearing" target="NearbyCharacters" range="150" stackable="true" setvalue="true">
+      <!-- <StatusEffect type="OnWearing" target="NearbyCharacters" range="150" stackable="true" setvalue="true">
         <Affliction identifier="stretchers" amount="100" />
+      </StatusEffect> -->
+      <StatusEffect type="OnWearing" target="Character" interval="0.25" disabledeltatime="true">
+        <LuaHook name="bodybag.dragfast" custom="Character" />
       </StatusEffect>
       <StatusEffect type="OnWearing" target="This" Condition="-0.25" />
       <StatusEffect type="OnBroken" target="This">


### PR DESCRIPTION
Fixed bagged bodies giving an area effect, causing all nearby players to be able to drag at normal speed.

Now they give the effect only to the individual who's dragging the body using a lua hook with 0.25 interval, shouldn't be much strain on the server.