### PR TITLE
(config setting) - Disable Consent Required

### DIFF
--- a/Neurotrauma/Lua/ConsentRequiredExtended/Config.lua
+++ b/Neurotrauma/Lua/ConsentRequiredExtended/Config.lua
@@ -5,58 +5,71 @@ local _ENV = Environment.PrepareEnvironment(_ENV)
 
 --------- Start editing here ---------
 
-AffectedItems = { 
--- Neurotrauma
-"healthscanner", --健康扫描仪
-"bloodanalyzer", --血液分析仪
-"opium", --药用鸦片
-"antidama1", --吗啡
-"antidama2", --芬太尼
-"antibleeding3", --抗生素凝膠
-"propofol", -- 异丙酚
-"mannitol", -- 甘露醇
-"pressuremeds", -- 压力药物
-"multiscalpel", -- 多功能手术刀
-"advscalpel", -- 手术刀
-"advhemostat", -- 止血钳
-"advretractors", -- 皮肤牵引器
-"tweezers", -- 镊子
-"surgicaldrill", -- 骨钻
-"surgerysaw", -- 手术锯
-"organscalpel_liver", -- 器官切割刀：肝脏
-"organscalpel_lungs", -- 器官切割刀：肺
-"organscalpel_kidneys", -- 器官切割刀：肾脏
-"organscalpel_heart", -- 器官切割刀：心脏
-"organscalpel_brain", -- 器官切割刀：大脑
-"emptybloodpack", -- 空血袋
-"alienblood", -- 异星血浆
-"tourniquet", -- 止血带
-"defibrillator", -- 手动除颤器
-"aed", -- 智能除颤器
-"bvm", -- 人工呼吸器
-"antibiotics", -- 广谱抗生素
-"sulphuricacid", -- 硫酸
-"divingknife", -- 潜水刀
-"divingknifedementonite", -- 攝魂潛水刀
-"divingknifehardened", -- 硬化潛水刀
-"crowbar", -- 潜水刀
-"crowbardementonite", -- 攝魂撬棍
-"crowbarhardened", -- 硬化撬棍
-"stasisbag", -- 冷藏袋
-"autocpr", -- 全自动CPR
--- NeuroEyes
-"organscalpel_eyes", -- 器官切割刀：眼睛
--- blahaj 布罗艾鲨鱼
-"blahaj", -- 布罗艾鲨鱼
-"blahajplus", -- 大鲨鲨
-"blahajplusplus", -- 超大鲨鲨
--- Pharmacy 制药大师
-"custompill", -- 自制药丸
-"custompill_horsepill", -- 大药丸
-"custompill_tablets", -- 药片
--- vanilla 原版
-"toyhammer" -- 玩具锤子
-}
+Timer.Wait(function()
+
+	if
+		not NTConfig.Get("NT_disableConsentRequired",false)
+	then
+		AffectedItems = { 
+		-- Neurotrauma
+		"healthscanner", --健康扫描仪
+		"bloodanalyzer", --血液分析仪
+		"opium", --药用鸦片
+		"antidama1", --吗啡
+		"antidama2", --芬太尼
+		"antibleeding3", --抗生素凝膠
+		"propofol", -- 异丙酚
+		"mannitol", -- 甘露醇
+		"pressuremeds", -- 压力药物
+		"multiscalpel", -- 多功能手术刀
+		"advscalpel", -- 手术刀
+		"advhemostat", -- 止血钳
+		"advretractors", -- 皮肤牵引器
+		"tweezers", -- 镊子
+		"surgicaldrill", -- 骨钻
+		"surgerysaw", -- 手术锯
+		"organscalpel_liver", -- 器官切割刀：肝脏
+		"organscalpel_lungs", -- 器官切割刀：肺
+		"organscalpel_kidneys", -- 器官切割刀：肾脏
+		"organscalpel_heart", -- 器官切割刀：心脏
+		"organscalpel_brain", -- 器官切割刀：大脑
+		"emptybloodpack", -- 空血袋
+		"alienblood", -- 异星血浆
+		"tourniquet", -- 止血带
+		"defibrillator", -- 手动除颤器
+		"aed", -- 智能除颤器
+		"bvm", -- 人工呼吸器
+		"antibiotics", -- 广谱抗生素
+		"sulphuricacid", -- 硫酸
+		"divingknife", -- 潜水刀
+		"divingknifedementonite", -- 攝魂潛水刀
+		"divingknifehardened", -- 硬化潛水刀
+		"crowbar", -- 潜水刀
+		"crowbardementonite", -- 攝魂撬棍
+		"crowbarhardened", -- 硬化撬棍
+		"stasisbag", -- 冷藏袋
+		"autocpr", -- 全自动CPR
+		-- NeuroEyes
+		"organscalpel_eyes", -- 器官切割刀：眼睛
+		-- blahaj 布罗艾鲨鱼
+		"blahaj", -- 布罗艾鲨鱼
+		"blahajplus", -- 大鲨鲨
+		"blahajplusplus", -- 超大鲨鲨
+		-- Pharmacy 制药大师
+		"custompill", -- 自制药丸
+		"custompill_horsepill", -- 大药丸
+		"custompill_tablets", -- 药片
+		-- vanilla 原版
+		"toyhammer" -- 玩具锤子
+		}
+	else
+		AffectedItems={}
+	end
+	
+--a little delay so that the NT config has time to load
+end,100)
+
+
 
 --------- Stop editing here ---------
 

--- a/Neurotrauma/Lua/ConsentRequiredExtended/Main.lua
+++ b/Neurotrauma/Lua/ConsentRequiredExtended/Main.lua
@@ -15,11 +15,13 @@ local HOOK_NAME_ITEM_APPLYTREATMENT = "ConsentRequiredExtended.onItemApplyTreatm
 local LUA_EVENT_MELEEWEAPON_HANDLEIMPACT = "meleeWeapon.handleImpact"
 local HOOK_NAME_MELEEWEAPON_HANDLEIMPACT = "ConsentRequiredExtended.onMeleeWeaponHandleImpact"
 
--- Set up affected items from config.
-for _, affectedItem in pairs(Config.AffectedItems) do
-    Api.AddAffectedItem(affectedItem)
-end
-
+Timer.Wait(function()
+	-- Set up affected items from config.
+	for _, affectedItem in pairs(Config.AffectedItems) do
+		Api.AddAffectedItem(affectedItem)
+	end
+--delay so that config can load
+end,110)
 Hook.Add(LUA_EVENT_ITEM_APPLYTREATMENT, HOOK_NAME_ITEM_APPLYTREATMENT, OnItemApplied)
 
 -- damn meleeWeapon

--- a/Neurotrauma/Lua/Scripts/Client/configgui.lua
+++ b/Neurotrauma/Lua/Scripts/Client/configgui.lua
@@ -57,7 +57,7 @@ easySettings.AddMenu("Neurotrauma", function (parent)
     OnChanged()
 	
 	--info text
-    GUI.TextBlock(GUI.RectTransform(Vector2(1, 0.2), list.Content.RectTransform), "Only the host can edit the servers config.\nEnter \"reloadlua\" in console to apply changes.\nFor dedicated servers you need to edit the file config.json, this GUI wont work.".."\n\n"..difficultyRate, Color(200,255,255), nil, GUI.Alignment.Center, true, nil, Color(0,0,0))
+    GUI.TextBlock(GUI.RectTransform(Vector2(1, 0.2), list.Content.RectTransform), "Only the host can edit the servers config.\nEnter \"reloadlua\" in console to apply changes.\nFor dedicated servers you need to edit the file config.json, this GUI will not work.".."\n\n"..difficultyRate, Color(200,255,255), nil, GUI.Alignment.Center, true, nil, Color(0,0,0))
 
 	--empty space
 	--GUI.TextBlock(GUI.RectTransform(Vector2(0.2, 0.1), list.Content.RectTransform), "", Color(255,255,255), nil, GUI.Alignment.Center, true, nil, Color(0,0,0))

--- a/Neurotrauma/Lua/Scripts/configdata.lua
+++ b/Neurotrauma/Lua/Scripts/configdata.lua
@@ -48,7 +48,7 @@ function NTConfig.LoadConfig()
 end
 
 function NTConfig.Get(key, default)
-    if NTConfig.Entries[key] then 
+    if NTConfig.Entries[key] then
         return NTConfig.Entries[key].value
     end
     return default
@@ -81,7 +81,8 @@ NT.ConfigData = {
 
     NT_vanillaSkillCheck =              {name="Vanilla skill check formula",default=false,type="bool",description="Changes the chance to succeed a lua skillcheck from skill/requiredskill to 100-(requiredskill-skill))/100"},
     NT_disableBotAlgorithms =           {name="Disable bot treatment algorithms",default=true,type="bool",description="Prevents bots from attempting to treat afflictions.\nThis is desireable, because bots suck at treating things, and their bad attempts lag out the game immensely."},
-    NT_screams =                        {name="Screams",default=true,type="bool",description="Characters scream when in pain."},
+    NT_disableConsentRequired =         {name="Disable Consent Required",default=false,type="bool",description="Disable integrated consent required mod.\n(If ticked, bots will not get aggravated by medical interactions.)"},
+	NT_screams =                        {name="Screams",default=true,type="bool",description="Characters scream when in pain."},
     NT_ignoreModConflicts =             {name="Ignore mod conflicts",default=false,type="bool",description="Prevent the mod conflict affliction from showing up."},
 
     NT_organRejection =                 {name="Organ rejection",default=false,type="bool",          difficultyCharacteristics={multiplier=0.5},description="When transplanting an organ, there is a chance that the organ gets rejected.\nThe higher the patients immunity at the time of the transplant, the higher the chance."},
@@ -98,6 +99,6 @@ Timer.Wait(function()
     Timer.Wait(function()
         NTConfig.SaveConfig()
     end,1000)
-
+	
 end,50)
 


### PR DESCRIPTION
This PR adds the option to disable consent required to NT config.

A bit janky due to the way consent required is written, preferably, in the long run, the smart thing to do would be to rewrite consent required as a proper integrated extension and have it have it's own config, so that the player can add/remove consent items from the list and manage mod values without having to go into mod files (like performance fix), but this should suffice for now.