### PR TITLE
Add limbtype argument for getresistance call

### DIFF
--- a/Neurotrauma/Lua/Scripts/helperfunctions.lua
+++ b/Neurotrauma/Lua/Scripts/helperfunctions.lua
@@ -306,7 +306,7 @@ end
 -- the main "mess with afflictions" function
 function HF.SetAfflictionLimb(character,identifier,limbtype,strength,aggressor,prevstrength)
     local prefab = AfflictionPrefab.Prefabs[identifier]
-    local resistance = character.CharacterHealth.GetResistance(prefab)
+    local resistance = character.CharacterHealth.GetResistance(prefab,limbtype)
     if resistance >= 1 then return end
 
     local strength = strength*character.CharacterHealth.MaxVitality/100/(1-resistance)


### PR DESCRIPTION
Should get no error for trying to convert void to clr type error from the last update.