### PR TITLE
Optimize: Set applyAffliction's recalculateVitality to false for most afflictions

### DIFF
--- a/Neurotrauma/Lua/Scripts/Server/ntcompat.lua
+++ b/Neurotrauma/Lua/Scripts/Server/ntcompat.lua
@@ -172,16 +172,22 @@ function NTC.AddSuturedAffliction(identifier,surgeryskillgain,requiredaffliction
 end
 
 NTC.AfflictionsAffectingVitality = {
+    bleeding = true,
+    bleedingnonstop = true,
+    burn = true,
+    acidburn = true,
+    lacerations = true,
+    gunshotwound = true,
+    bitewounds = true,
+    explosiondamage = true,
+    blunttrauma = true,
+    internaldamage = true,
+    organdamage = true,
     cerebralhypoxia = true,
     gangrene = true,
     th_amputation = true,
     sh_amputation = true,
     suturedw = true,
-    internaldamage = true,
-    blunttrauma = true,
-    organdamage = true,
-    burn = true,
-    acidburn = true,
     alcoholaddiction = true,
     opiateaddiction = true,
 }

--- a/Neurotrauma/Lua/Scripts/Server/ntcompat.lua
+++ b/Neurotrauma/Lua/Scripts/Server/ntcompat.lua
@@ -171,6 +171,24 @@ function NTC.AddSuturedAffliction(identifier,surgeryskillgain,requiredaffliction
     end,1)
 end
 
+NTC.AfflictionsAffectingVitality = {
+    cerebralhypoxia = true,
+    gangrene = true,
+    th_amputation = true,
+    sh_amputation = true,
+    suturedw = true,
+    internaldamage = true,
+    blunttrauma = true,
+    organdamage = true,
+    burn = true,
+    acidburn = true,
+    alcoholaddiction = true,
+    opiateaddiction = true,
+}
+function NTC.AddAfflictionAffectingVitality(identifier)
+    NTC.AfflictionsAffectingVitality[identifier] = true
+end
+
 -- these functions are used by neurotrauma to check for symptom overrides
 function NTC.GetSymptom(character,symptomidentifer)
     local chardata = NTC.GetCharacterData(character)

--- a/Neurotrauma/Lua/Scripts/helperfunctions.lua
+++ b/Neurotrauma/Lua/Scripts/helperfunctions.lua
@@ -313,8 +313,9 @@ function HF.SetAfflictionLimb(character,identifier,limbtype,strength,aggressor,p
     local affliction = prefab.Instantiate(
         strength
         ,aggressor)
+    local recalculateVitality = NTC.AfflictionsAffectingVitality[identifier] ~= nil
 
-    character.CharacterHealth.ApplyAffliction(character.AnimController.GetLimb(limbtype),affliction,false)
+    character.CharacterHealth.ApplyAffliction(character.AnimController.GetLimb(limbtype), affliction, false, recalculateVitality)
 
     -- turn target aggressive if damaging
 --    if(aggressor ~= nil and character~=aggressor) then 


### PR DESCRIPTION
Vanilla's latest update added "optimizations to afflictions" including adding a `recalculateVitality = true` parameter to ApplyAffliction and ApplyDamage.

Since NT adds so many afflictions that don't affect vitality directly, we can set this to false in most cases to gain that perf benefit.

Its probably not critically important that NT addons adding new vitality-affecting afflictions (eg. Hyperbarics) include themselves in this list (though I've added an `NTC.AddAfflictionAffectingVitality(identifier)` in case they want to) since vitality will very likely be updated by one of the common damage types or neurotrauma eventually anyway.