### PR TITLE
Network config menu

### DIFF
--- a/Neurotrauma/Lua/Autorun/init.lua
+++ b/Neurotrauma/Lua/Autorun/init.lua
@@ -59,6 +59,20 @@ if (Game.IsMultiplayer and SERVER) or not Game.IsMultiplayer then
     dofile(NT.Path.."/Lua/Scripts/testing.lua")
 end
 
+-- server-side code only
+if SERVER then
+    Networking.Receive("NT.ConfigUpdate", function(msg, sender)
+        if not sender.HasPermission(ClientPermissions.ManageSettings) then return end
+        NTConfig.ReceiveConfig(msg)
+        NTConfig.SaveConfig()
+    end)
+
+    Networking.Receive("NT.ConfigRequest", function(msg, sender)
+        if not sender then return end
+        NTConfig.SendConfig(sender)
+    end)
+end
+
 -- client-side code
 if CLIENT then
     dofile(NT.Path.."/Lua/Scripts/Client/configgui.lua")

--- a/Neurotrauma/Lua/Scripts/Client/easysettings.lua
+++ b/Neurotrauma/Lua/Scripts/Client/easysettings.lua
@@ -84,7 +84,11 @@ easySettings.SaveButton = function (parent)
     local button = GUI.Button(GUI.RectTransform(Vector2(0.33, 0.05), parent.RectTransform, GUI.Anchor.BottomLeft), "Save and Exit", GUI.Alignment.Center, "GUIButton")
 
     button.OnClicked = function ()
-		NTConfig.SaveConfig()
+        if Game.IsMultiplayer and Game.Client.HasPermission(ClientPermissions.ManageSettings) then
+            NTConfig.SendConfig()
+        elseif Game.IsSingleplayer then
+            NTConfig.SaveConfig()
+        end
         GUI.GUI.TogglePauseMenu()
     end
 
@@ -108,12 +112,31 @@ easySettings.ResetButton = function (parent)
     local button = GUI.Button(GUI.RectTransform(Vector2(0.33, 0.05), parent.RectTransform, GUI.Anchor.BottomRight), "Reset Config", GUI.Alignment.Center, "GUIButton")
 
     button.OnClicked = function ()
-		NTConfig.ResetConfig()
-        GUI.GUI.TogglePauseMenu()
+        if Game.IsSingleplayer or (Game.IsMultiplayer and Game.Client.HasPermission(ClientPermissions.ManageSettings)) then
+            easySettings.ResetMessage(parent)
+        end
     end
-
     return button
 end
 
+easySettings.ResetMessage = function(parent)
+    local ResetMessage = GUI.MessageBox("Reset neurotrauma settings", "Are you sure you want to reset neurotrauma settings to default values?", {"Yes", "No"})
+    ResetMessage.DrawOnTop = true
+    ResetMessage.Text.TextAlignment = GUI.Alignment.Center
+    ResetMessage.Buttons[1].OnClicked = function()
+        NTConfig.ResetConfig()
+        if Game.IsMultiplayer and Game.Client.HasPermission(ClientPermissions.ManageSettings) then
+            NTConfig.SendConfig()
+        elseif Game.IsSingleplayer then
+            NTConfig.SaveConfig()
+        end
+        GUI.GUI.TogglePauseMenu()
+        ResetMessage.Close()
+    end
+    ResetMessage.Buttons[2].OnClicked = function()
+        ResetMessage.Close()
+    end
+    return ResetMessage
+end
 
 return easySettings


### PR DESCRIPTION
Server configs now can be directly changed in config menu and updated immediately without needing to reload lua
Clients see current server config, if they dont have ManageSettings permission the menu is grayed out.
Clients dont save to local file in multiplayer so they dont change their own settings file unnecessarily.
Reset button now has confirmation message to prevent missclicks.