### PR TITLE
Hematology Analyzer: allow scanning blood bags

### DIFF
--- a/Neurotrauma/Lua/Scripts/Server/humanupdate.lua
+++ b/Neurotrauma/Lua/Scripts/Server/humanupdate.lua
@@ -1248,6 +1248,10 @@ function NT.UpdateHuman(character)
         end
     end
 
+    if character.IsPlayer then
+        NT.RunBloodAnalyzers(character)
+    end
+
     -- compatibility
     NTC.TickCharacter(character)
     -- humanupdate hooks
@@ -1290,4 +1294,53 @@ function NT.AddTickTask(type,duration,character)
     newtask.character=character
     NT.tickTasks[NT.tickTaskID]=newtask
     NT.tickTaskID = NT.tickTaskID+1
+end
+
+local lastScannedBloodPack = {}
+function NT.RunBloodAnalyzers(character)
+    -- Look for Hematology Analyzers in the quickbar containing blood packs
+    for item in character.Inventory.AllItems do
+        if item.Prefab.Identifier.Value == "bloodanalyzer" then
+            local contained = item.OwnInventory.GetItemAt(0)
+
+            -- NT adds bloodbag; NT Blood Work or 'Real Sonar Medical Item Recipes Patch for Neurotrauma' add allblood, lets check for either
+            if contained ~= nil and (contained.HasTag("bloodbag") or contained.HasTag("allblood")) and lastScannedBloodPack[item] ~= contained then
+                lastScannedBloodPack[item] = contained
+                local identifier = contained.Prefab.Identifier.Value
+                local packtype = "o-"
+                if identifier ~= "antibloodloss2" then
+                    packtype = string.sub(identifier, string.len("bloodpack")+1)
+                end
+
+                local bloodTypeDisplay = string.gsub(packtype, "abc", "c")
+                bloodTypeDisplay = string.gsub(bloodTypeDisplay, "plus", "+")
+                bloodTypeDisplay = string.gsub(bloodTypeDisplay, "minus", "-")
+                bloodTypeDisplay = string.upper(bloodTypeDisplay)
+                local readoutString = "Bloodpack: " .. bloodTypeDisplay .. "\n"
+                -- check if acidosis, alkalosis or sepsis
+                local tags = HF.SplitString(contained.Tags,",")
+                for tag in tags do
+                    if tag == "sepsis" then
+                        readoutString = readoutString .. "Sepsis detected\n"
+                     end
+
+                    if HF.StartsWith(tag,"acid") then
+                        local split = HF.SplitString(tag,":")
+                        if split[2] ~= nil then
+                            readoutString = readoutString .. "Acidosis: " .. tonumber(split[2]) .. "%\n"
+                        end
+                    elseif HF.StartsWith(tag,"alkal") then
+                        local split = HF.SplitString(tag,":")
+                        if split[2] ~= nil then
+                            readoutString = readoutString .. "Alkalosis: " .. tonumber(split[2]) .. "%\n"
+                        end
+                    end
+                end
+
+                HF.DMClient(HF.CharacterToClient(character), readoutString, Color(127,255,255,255))
+                HF.GiveItem(character,"ntsfx_syringe")
+            end
+            break
+        end
+    end
 end

--- a/Neurotrauma/Lua/Scripts/Server/items.lua
+++ b/Neurotrauma/Lua/Scripts/Server/items.lua
@@ -96,7 +96,7 @@ NT.ItemMethods.bloodanalyzer = function(item, usingCharacter, targetCharacter, l
 
     -- spawn donor card
     local containedItem = item.OwnInventory.GetItemAt(0)
-    local hasCartridge = containedItem ~= nil
+    local hasCartridge = containedItem ~= nil and (containedItem.Prefab.Identifier.Value == "bloodcollector" or containedItem.HasTag("donorCard"))
     if hasCartridge then 
         HF.RemoveItem(containedItem)
         local bloodtype = NT.GetBloodtype(targetCharacter)

--- a/Neurotrauma/Xml/items.xml
+++ b/Neurotrauma/Xml/items.xml
@@ -1708,7 +1708,7 @@
 
     <ItemContainer capacity="1" maxstacksize="1" canbeselected="false" hideitems="true" drawinventory="true">
       <Containable
-              items="bloodcollector, ominuscard, opluscard, aminuscard ,apluscard ,bminuscard ,bpluscard ,abminuscard , abpluscard, bloodscannercard, donorCard"/>
+              items="bloodcollector, ominuscard, opluscard, aminuscard ,apluscard ,bminuscard ,bpluscard ,abminuscard , abpluscard, bloodscannercard, donorCard, bloodbag, allblood"/>
     </ItemContainer>
     <SkillRequirementHint identifier="medical" level="30"/>
   </Item>

--- a/Neurotrauma/Xml/items.xml
+++ b/Neurotrauma/Xml/items.xml
@@ -1707,8 +1707,11 @@
     <Pickable msg="ItemMsgPickUpSelect"/>
 
     <ItemContainer capacity="1" maxstacksize="1" canbeselected="false" hideitems="true" drawinventory="true">
-      <Containable
-              items="bloodcollector, ominuscard, opluscard, aminuscard ,apluscard ,bminuscard ,bpluscard ,abminuscard , abpluscard, bloodscannercard, donorCard, bloodbag, allblood"/>
+      <Containable items="bloodcollector, ominuscard, opluscard, aminuscard ,apluscard ,bminuscard ,bpluscard ,abminuscard , abpluscard, bloodscannercard, donorCard, bloodbag, allblood">
+        <StatusEffect type="OnInserted" target="this">
+          <LuaHook name="OnInsertedIntoBloodAnalyzer" />
+        </StatusEffect>
+      </Containable>
     </ItemContainer>
     <SkillRequirementHint identifier="medical" level="30"/>
   </Item>


### PR DESCRIPTION
This introduces a way to determine whether a Blood Pack is tainted by sepsis/alkalosis/acidosis: the Hematology Analyzer's inventory slot can now accept either a donor card, or a blood pack.

~The Hematology Analyzer is not equippable, and I couldn't think of a better way to check for the pack being inserted, so instead:
I'm checking in humanupdate.lua (so, about every 2 seconds, which feels quite reasonable) if the character is a player, with a scanner in their toolbar, with a blood pack contained, that wasn't the most recent pack that scanner has analyzed. If so,~
When a blood pack is inserted into the analyzer, it prints out the stats (reusing code from the Analyzer and InfuseBloodPack) after a short delay.
