### PR TITLE
Fractured skull rework

### DIFF
--- a/Neurotrauma/Characters/Human/Ragdolls/HumanDefaultRagdoll.xml
+++ b/Neurotrauma/Characters/Human/Ragdolls/HumanDefaultRagdoll.xml
@@ -13,7 +13,7 @@
     <tintmask texture="Content/Characters/Human/Human_[GENDER]_heads_mask.png" />
     <huskmask texture="Content/Characters/Human/Human_husk_mask.png" />
     <damagedsprite texture="Content/Characters/Human/Human_damage.png" sourcerect="0,0,128,128"/>
-    <damagemodifier damagemultiplier="2" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,explosiondamage" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
+    <damagemodifier damagemultiplier="3" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,explosiondamage" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
     <conditionalsprite exclusive="True">
       <conditional th_amputation="gt 0"/>
       <sprite texture="%ModDir%/Images/Human/Human_[GENDER].png" sourcerect="190,510,50,10" depth="0.05" origin="0.5,0.5" color="255,255,255,255" deadcolor="255,255,255,255" deadcolortime="0" ignoretint="False" />

--- a/Neurotrauma/Characters/Human/Ragdolls/HumanDefaultRagdoll.xml
+++ b/Neurotrauma/Characters/Human/Ragdolls/HumanDefaultRagdoll.xml
@@ -27,7 +27,7 @@
     <sprite texture="" sourcerect="272,0,64,96" origin="0.5,0.5" depth="0.02" color="255,255,255,255" deadcolor="255,255,255,255" deadcolortime="0" ignoretint="False" />
     <tintmask texture="%ModDir%/Images/Human/Human_[GENDER]_mask.png" />
     <damagedsprite texture="Content/Characters/Human/Human_damageoverlay.png" sourcerect="272,0,64,96"/>
-    <damagemodifier damagemultiplier="0.7" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,bitewounds" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
+    <damagemodifier damagemultiplier="0.7" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,bitewounds,explosiondamage" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
     <damagemodifier damagemultiplier="0.75" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="bleeding" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
   
     <conditionalsprite exclusive="False">
@@ -39,7 +39,7 @@
     <sprite texture="" sourcerect="272,160,64,48" origin="0.44,0.4" depth="0.015" color="255,255,255,255" deadcolor="255,255,255,255" deadcolortime="0" ignoretint="False" />
     <tintmask texture="%ModDir%/Images/Human/Human_[GENDER]_mask.png" />
     <damagedsprite texture="Content/Characters/Human/Human_damageoverlay.png" sourcerect="272,160,64,48"/>
-    <damagemodifier damagemultiplier="0.7" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,bitewounds" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
+    <damagemodifier damagemultiplier="0.7" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,bitewounds,explosiondamage" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
     <damagemodifier damagemultiplier="0.75" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="bleeding" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
     
     <conditionalsprite exclusive="True">
@@ -61,7 +61,7 @@
     <sprite texture="" sourcerect="336,0,64,96" origin="0.5,0.5" depth="0.14" color="255,255,255,255" deadcolor="255,255,255,255" deadcolortime="0" ignoretint="False" />
     <tintmask texture="%ModDir%/Images/Human/Human_[GENDER]_mask.png" />
     <damagedsprite texture="Content/Characters/Human/Human_damageoverlay.png" sourcerect="336,0,64,96"/>
-    <damagemodifier damagemultiplier="0.7" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,bitewounds" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
+    <damagemodifier damagemultiplier="0.7" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,bitewounds,explosiondamage" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
     <damagemodifier damagemultiplier="0.75" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="bleeding" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
   
     <conditionalsprite exclusive="False">
@@ -73,7 +73,7 @@
     <sprite texture="" sourcerect="336,160,64,48" origin="0.44,0.4" depth="0.16" color="255,255,255,255" deadcolor="255,255,255,255" deadcolortime="0" ignoretint="False" />
     <tintmask texture="%ModDir%/Images/Human/Human_[GENDER]_mask.png" />
     <damagedsprite texture="Content/Characters/Human/Human_damageoverlay.png" sourcerect="336,160,64,48"/>
-    <damagemodifier damagemultiplier="0.7" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,bitewounds" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
+    <damagemodifier damagemultiplier="0.7" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,bitewounds,explosiondamage" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
     <damagemodifier damagemultiplier="0.75" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="bleeding" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
     
     <conditionalsprite exclusive="True">
@@ -96,7 +96,7 @@
     <sprite texture="" sourcerect="80,0,80,128" origin="0.5,0.5" depth="0.13" color="255,255,255,255" deadcolor="255,255,255,255" deadcolortime="0" ignoretint="False" />
     <tintmask texture="%ModDir%/Images/Human/Human_[GENDER]_mask.png" />
     <damagedsprite texture="Content/Characters/Human/Human_damageoverlay.png" sourcerect="80,0,80,128"/>
-    <damagemodifier damagemultiplier="0.7" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,bitewounds" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
+    <damagemodifier damagemultiplier="0.7" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,bitewounds,explosiondamage" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
     <damagemodifier damagemultiplier="0.75" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="bleeding" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
   
     <conditionalsprite exclusive="False">
@@ -108,7 +108,7 @@
     <sprite texture="" sourcerect="80,128,80,128" origin="0.5,0.5" depth="0.131" color="255,255,255,255" deadcolor="255,255,255,255" deadcolortime="0" ignoretint="False" />
     <tintmask texture="%ModDir%/Images/Human/Human_[GENDER]_mask.png" />
     <damagedsprite texture="Content/Characters/Human/Human_damageoverlay.png" sourcerect="80,128,80,128"/>
-    <damagemodifier damagemultiplier="0.7" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,bitewounds" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
+    <damagemodifier damagemultiplier="0.7" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,bitewounds,explosiondamage" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
     <damagemodifier damagemultiplier="0.75" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="bleeding" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
     
     <conditionalsprite exclusive="True">
@@ -131,7 +131,7 @@
     <tintmask texture="%ModDir%/Images/Human/Human_[GENDER]_mask.png" />
     <sound tag="footstep_metal" />
     <damagedsprite texture="Content/Characters/Human/Human_damageoverlay.png" sourcerect="336,208,64,48"/>
-    <damagemodifier damagemultiplier="0.7" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,bitewounds" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
+    <damagemodifier damagemultiplier="0.7" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,bitewounds,explosiondamage" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
     <damagemodifier damagemultiplier="0.75" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="bleeding" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
     
     <conditionalsprite exclusive="True">
@@ -153,7 +153,7 @@
     <sprite texture="" sourcerect="0,0,80,128" origin="0.5,0.5" depth="0.12" color="255,255,255,255" deadcolor="255,255,255,255" deadcolortime="0" ignoretint="False" />
     <tintmask texture="%ModDir%/Images/Human/Human_[GENDER]_mask.png" />
     <damagedsprite texture="Content/Characters/Human/Human_damageoverlay.png" sourcerect="0,0,80,128"/>
-    <damagemodifier damagemultiplier="0.7" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,bitewounds" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
+    <damagemodifier damagemultiplier="0.7" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,bitewounds,explosiondamage" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
     <damagemodifier damagemultiplier="0.75" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="bleeding" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
   
     <conditionalsprite exclusive="False">
@@ -165,7 +165,7 @@
     <sprite texture="" sourcerect="0,128,80,128" origin="0.5,0.5" depth="0.121" color="255,255,255,255" deadcolor="255,255,255,255" deadcolortime="0" ignoretint="False" />
     <tintmask texture="%ModDir%/Images/Human/Human_[GENDER]_mask.png" />
     <damagedsprite texture="Content/Characters/Human/Human_damageoverlay.png" sourcerect="0,128,80,128"/>
-    <damagemodifier damagemultiplier="0.7" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,bitewounds" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
+    <damagemodifier damagemultiplier="0.7" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,bitewounds,explosiondamage" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
     <damagemodifier damagemultiplier="0.75" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="bleeding" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
     
     <conditionalsprite exclusive="True">
@@ -189,7 +189,7 @@
     <tintmask texture="%ModDir%/Images/Human/Human_[GENDER]_mask.png" />
     <sound tag="footstep_metal" />
     <damagedsprite texture="Content/Characters/Human/Human_damageoverlay.png" sourcerect="272,208,64,48"/>
-    <damagemodifier damagemultiplier="0.7" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,bitewounds" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
+    <damagemodifier damagemultiplier="0.7" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,bitewounds,explosiondamage" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
     <damagemodifier damagemultiplier="0.75" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="bleeding" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
     
     <conditionalsprite exclusive="True">
@@ -218,7 +218,7 @@
     <sprite texture="" sourcerect="336,96,64,64" origin="0.5,0.5" depth="0.15" color="255,255,255,255" deadcolor="255,255,255,255" deadcolortime="0" ignoretint="False" />
     <tintmask texture="%ModDir%/Images/Human/Human_[GENDER]_mask.png" />
     <damagedsprite texture="Content/Characters/Human/Human_damageoverlay.png" sourcerect="336,96,64,64"/>
-    <damagemodifier damagemultiplier="0.7" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,bitewounds" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
+    <damagemodifier damagemultiplier="0.7" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,bitewounds,explosiondamage" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
     <damagemodifier damagemultiplier="0.75" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="bleeding" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
     
     <conditionalsprite exclusive="True">
@@ -241,7 +241,7 @@
     <sprite texture="" sourcerect="272,96,64,64" origin="0.5,0.5" depth="0.01" color="255,255,255,255" deadcolor="255,255,255,255" deadcolortime="0" ignoretint="False" />
     <tintmask texture="%ModDir%/Images/Human/Human_[GENDER]_mask.png" />
     <damagedsprite texture="Content/Characters/Human/Human_damageoverlay.png" sourcerect="272,96,64,64"/>
-    <damagemodifier damagemultiplier="0.7" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,bitewounds" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
+    <damagemodifier damagemultiplier="0.7" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,bitewounds,explosiondamage" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
     <damagemodifier damagemultiplier="0.75" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="bleeding" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
 
     <conditionalsprite exclusive="True">

--- a/Neurotrauma/Characters/Human/Ragdolls/HumanDefaultRagdoll.xml
+++ b/Neurotrauma/Characters/Human/Ragdolls/HumanDefaultRagdoll.xml
@@ -13,7 +13,7 @@
     <tintmask texture="Content/Characters/Human/Human_[GENDER]_heads_mask.png" />
     <huskmask texture="Content/Characters/Human/Human_husk_mask.png" />
     <damagedsprite texture="Content/Characters/Human/Human_damage.png" sourcerect="0,0,128,128"/>
-    <damagemodifier damagemultiplier="3" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
+    <damagemodifier damagemultiplier="2" armorsector="0,360" deflectprojectiles="False" afflictionidentifiers="gunshotwound,lacerations,blunttrauma,explosiondamage" damagesound="" afflictiontypes="" probabilitymultiplier="1" damageparticle="" />
     <conditionalsprite exclusive="True">
       <conditional th_amputation="gt 0"/>
       <sprite texture="%ModDir%/Images/Human/Human_[GENDER].png" sourcerect="190,510,50,10" depth="0.05" origin="0.5,0.5" color="255,255,255,255" deadcolor="255,255,255,255" deadcolortime="0" ignoretint="False" />

--- a/Neurotrauma/Lua/Scripts/Server/humanupdate.lua
+++ b/Neurotrauma/Lua/Scripts/Server/humanupdate.lua
@@ -387,7 +387,7 @@ NT.Afflictions = {
 			end
 			-- calculate new neurotrauma
 			local gain = (
-				-0.1 * c.stats.healingrate -- passive regen
+				-0.1 * c.stats.healingrate * (1 - c.afflictions.h_fracture.strength / 100) -- passive regen and fractured skull
 				+ c.afflictions.hypoxemia.strength / 100 -- from hypoxemia
 				+ HF.Clamp(c.afflictions.stroke.strength, 0, 20) * 0.1 -- from stroke
 				+ c.afflictions.sepsis.strength / 100 * 0.4 -- from sepsis

--- a/Neurotrauma/Lua/Scripts/Server/humanupdate.lua
+++ b/Neurotrauma/Lua/Scripts/Server/humanupdate.lua
@@ -386,8 +386,10 @@ NT.Afflictions = {
 				return
 			end
 			-- calculate new neurotrauma
+			local skull = HF.HasAffliction(c.character, "h_fracture", 1) -- check for skullfracture
+			local skullmod = skull and 0 or 1 -- invert bool
 			local gain = (
-				-0.1 * c.stats.healingrate * (1 - c.afflictions.h_fracture.strength / 100) -- passive regen and fractured skull
+				-0.1 * c.stats.healingrate * (skullmod) -- passive regen and fractured skull
 				+ c.afflictions.hypoxemia.strength / 100 -- from hypoxemia
 				+ HF.Clamp(c.afflictions.stroke.strength, 0, 20) * 0.1 -- from stroke
 				+ c.afflictions.sepsis.strength / 100 * 0.4 -- from sepsis

--- a/Neurotrauma/Lua/Scripts/Server/ondamaged.lua
+++ b/Neurotrauma/Lua/Scripts/Server/ondamaged.lua
@@ -140,12 +140,14 @@ NT.OnDamagedMethods.gunshotwound = function(character, strength, limbtype)
 	if strength >= 1 and limbtype == LimbType.Head then
 		if
 			HF.Chance(
-				strength / 60 * NTC.GetMultiplier(character, "anyfracturechance") * NTConfig.Get("NT_fractureChance", 1)
+				strength / 90 * NTC.GetMultiplier(character, "anyfracturechance") * NTConfig.Get("NT_fractureChance", 1)
 			)
 		then
 			NT.BreakLimb(character, limbtype)
 			causeFullForeignBody = true
-			HF.AddAffliction(character, "cerebralhypoxia", strength)
+		end
+		if strength >= 5 and HF.Chance(0.7) then
+			HF.AddAffliction(character, "cerebralhypoxia", strength * HF.RandomRange(0.1, 0.4))
 		end
 	end
 
@@ -250,7 +252,6 @@ NT.OnDamagedMethods.explosiondamage = function(character, strength, limbtype)
 			)
 		then
 			NT.BreakLimb(character, limbtype)
-			HF.AddAffliction(character, "cerebralhypoxia", strength)
 		end
 		if
 			strength >= 15
@@ -354,7 +355,6 @@ NT.OnDamagedMethods.bitewounds = function(character, strength, limbtype)
 			)
 		then
 			NT.BreakLimb(character, limbtype)
-			HF.AddAffliction(character, "cerebralhypoxia", strength / 5)
 		end
 	end
 
@@ -437,7 +437,6 @@ NT.OnDamagedMethods.lacerations = function(character, strength, limbtype)
 			)
 		then
 			NT.BreakLimb(character, limbtype)
-			HF.AddAffliction(character, "cerebralhypoxia", strength)
 		end
 	end
 
@@ -521,7 +520,6 @@ NT.OnDamagedMethods.blunttrauma = function(character, strength, limbtype)
 			)
 		then
 			NT.BreakLimb(character, limbtype)
-			HF.AddAffliction(character, "cerebralhypoxia", strength)
 		end
 		if
 			strength >= 15
@@ -629,7 +627,6 @@ NT.OnDamagedMethods.internaldamage = function(character, strength, limbtype)
 			)
 		then
 			NT.BreakLimb(character, limbtype)
-			HF.AddAffliction(character, "cerebralhypoxia", strength / 5)
 		end
 		if
 			strength >= 15

--- a/Neurotrauma/Lua/Scripts/Server/ondamaged.lua
+++ b/Neurotrauma/Lua/Scripts/Server/ondamaged.lua
@@ -145,7 +145,7 @@ NT.OnDamagedMethods.gunshotwound = function(character, strength, limbtype)
 		then
 			NT.BreakLimb(character, limbtype)
 			causeFullForeignBody = true
-			HF.AddAffliction(character, "cerebralhypoxia", strength)
+			HF.AddAffliction(character, "cerebralhypoxia", strength / 2)
 		end
 	end
 
@@ -250,7 +250,7 @@ NT.OnDamagedMethods.explosiondamage = function(character, strength, limbtype)
 			)
 		then
 			NT.BreakLimb(character, limbtype)
-			HF.AddAffliction(character, "cerebralhypoxia", strength)
+			HF.AddAffliction(character, "cerebralhypoxia", strength / 2)
 		end
 		if
 			strength >= 15
@@ -437,7 +437,7 @@ NT.OnDamagedMethods.lacerations = function(character, strength, limbtype)
 			)
 		then
 			NT.BreakLimb(character, limbtype)
-			HF.AddAffliction(character, "cerebralhypoxia", strength)
+			HF.AddAffliction(character, "cerebralhypoxia", strength / 2)
 		end
 	end
 
@@ -521,7 +521,7 @@ NT.OnDamagedMethods.blunttrauma = function(character, strength, limbtype)
 			)
 		then
 			NT.BreakLimb(character, limbtype)
-			HF.AddAffliction(character, "cerebralhypoxia", strength)
+			HF.AddAffliction(character, "cerebralhypoxia", strength / 2)
 		end
 		if
 			strength >= 15

--- a/Neurotrauma/Lua/Scripts/Server/ondamaged.lua
+++ b/Neurotrauma/Lua/Scripts/Server/ondamaged.lua
@@ -140,14 +140,12 @@ NT.OnDamagedMethods.gunshotwound = function(character, strength, limbtype)
 	if strength >= 1 and limbtype == LimbType.Head then
 		if
 			HF.Chance(
-				strength / 90 * NTC.GetMultiplier(character, "anyfracturechance") * NTConfig.Get("NT_fractureChance", 1)
+				strength / 60 * NTC.GetMultiplier(character, "anyfracturechance") * NTConfig.Get("NT_fractureChance", 1)
 			)
 		then
 			NT.BreakLimb(character, limbtype)
 			causeFullForeignBody = true
-		end
-		if strength >= 5 and HF.Chance(0.7) then
-			HF.AddAffliction(character, "cerebralhypoxia", strength * HF.RandomRange(0.1, 0.4))
+			HF.AddAffliction(character, "cerebralhypoxia", strength)
 		end
 	end
 
@@ -252,6 +250,7 @@ NT.OnDamagedMethods.explosiondamage = function(character, strength, limbtype)
 			)
 		then
 			NT.BreakLimb(character, limbtype)
+			HF.AddAffliction(character, "cerebralhypoxia", strength)
 		end
 		if
 			strength >= 15
@@ -355,6 +354,7 @@ NT.OnDamagedMethods.bitewounds = function(character, strength, limbtype)
 			)
 		then
 			NT.BreakLimb(character, limbtype)
+			HF.AddAffliction(character, "cerebralhypoxia", strength / 5)
 		end
 	end
 
@@ -437,6 +437,7 @@ NT.OnDamagedMethods.lacerations = function(character, strength, limbtype)
 			)
 		then
 			NT.BreakLimb(character, limbtype)
+			HF.AddAffliction(character, "cerebralhypoxia", strength)
 		end
 	end
 
@@ -520,6 +521,7 @@ NT.OnDamagedMethods.blunttrauma = function(character, strength, limbtype)
 			)
 		then
 			NT.BreakLimb(character, limbtype)
+			HF.AddAffliction(character, "cerebralhypoxia", strength)
 		end
 		if
 			strength >= 15
@@ -627,6 +629,7 @@ NT.OnDamagedMethods.internaldamage = function(character, strength, limbtype)
 			)
 		then
 			NT.BreakLimb(character, limbtype)
+			HF.AddAffliction(character, "cerebralhypoxia", strength / 5)
 		end
 		if
 			strength >= 15

--- a/Neurotrauma/Lua/Scripts/Server/ondamaged.lua
+++ b/Neurotrauma/Lua/Scripts/Server/ondamaged.lua
@@ -145,7 +145,7 @@ NT.OnDamagedMethods.gunshotwound = function(character, strength, limbtype)
 		then
 			NT.BreakLimb(character, limbtype)
 			causeFullForeignBody = true
-			HF.AddAffliction(character, "cerebralhypoxia", strength / 2)
+			HF.AddAffliction(character, "cerebralhypoxia", strength)
 		end
 	end
 
@@ -250,7 +250,7 @@ NT.OnDamagedMethods.explosiondamage = function(character, strength, limbtype)
 			)
 		then
 			NT.BreakLimb(character, limbtype)
-			HF.AddAffliction(character, "cerebralhypoxia", strength / 2)
+			HF.AddAffliction(character, "cerebralhypoxia", strength)
 		end
 		if
 			strength >= 15
@@ -437,7 +437,7 @@ NT.OnDamagedMethods.lacerations = function(character, strength, limbtype)
 			)
 		then
 			NT.BreakLimb(character, limbtype)
-			HF.AddAffliction(character, "cerebralhypoxia", strength / 2)
+			HF.AddAffliction(character, "cerebralhypoxia", strength)
 		end
 	end
 
@@ -521,7 +521,7 @@ NT.OnDamagedMethods.blunttrauma = function(character, strength, limbtype)
 			)
 		then
 			NT.BreakLimb(character, limbtype)
-			HF.AddAffliction(character, "cerebralhypoxia", strength / 2)
+			HF.AddAffliction(character, "cerebralhypoxia", strength)
 		end
 		if
 			strength >= 15

--- a/Neurotrauma/Xml/Afflictions.xml
+++ b/Neurotrauma/Xml/Afflictions.xml
@@ -1256,14 +1256,6 @@
       </StatusEffect>
     </Effect>
     <Effect minstrength="6" maxstrength="100"/>
-
-    <PeriodicEffect mininterval="30" maxinterval="60">
-      <StatusEffect target="Character" multiplyafflictionsbymaxvitality="true" comparison="And">
-        <Conditional bandaged="lte 1" cerebralhypoxia="lte 1"/>
-        <Affliction identifier="cerebralhypoxia" amount="20" probability="0.5" />
-        <Affliction identifier="cerebralhypoxia" amount="30" probability="0.15" />
-      </StatusEffect>
-    </PeriodicEffect>
 		<icon texture="%ModDir%/Images/AfflictionIcons.png" sheetindex="2,3" sheetelementsize="128,128" origin="0,0"/>
   </Affliction>
   


### PR DESCRIPTION
Myself and other players have found the fractured skull condition to be underwhelming. This rework changes fractured skull to prevent the natural decrease of neurotrauma at full strength. This means that fractured skull is not a lethal condition by itself (just like the other fractures, except neck), but can be a problem if ignored.

Detailed changes
- skull fracture no longer causes neurotrauma by itself
- skull fracture prevents natural regeneration of neurotrauma
- deep tissue injury is now affected by the limb damage multipliers