### PR TITLE
Reworked Config GUI

### DIFF
--- a/Neurotrauma/Lua/Scripts/Client/configgui.lua
+++ b/Neurotrauma/Lua/Scripts/Client/configgui.lua
@@ -69,7 +69,7 @@ local function ConstructUI(parent)
 
 	--info text
 	local userBlock = GUI.TextBlock(
-		GUI.RectTransform(Vector2(1, 0.2), list.Content.RectTransform),
+		GUI.RectTransform(Vector2(1, 0.1), list.Content.RectTransform),
 		"Server config can be changed by owner or a client with manage settings permission. If the server doesn't allow writing into the config folder, then it must be edited manually.",
 		Color(200, 255, 255),
 		nil,
@@ -79,7 +79,7 @@ local function ConstructUI(parent)
 		Color(0, 0, 0)
 	)
 	local difficultyBlock = GUI.TextBlock(
-		GUI.RectTransform(Vector2(1, 0.1), list.Content.RectTransform),
+		GUI.RectTransform(Vector2(1, 0.05), list.Content.RectTransform),
 		"",
 		Color(200, 255, 255),
 		nil,
@@ -95,9 +95,6 @@ local function ConstructUI(parent)
 		difficultyBlock.Text = difficultyRate
 	end
 	OnChanged()
-
-	--empty space
-	--GUI.TextBlock(GUI.RectTransform(Vector2(0.2, 0.1), list.Content.RectTransform), "", Color(255,255,255), nil, GUI.Alignment.Center, true, nil, Color(0,0,0))
 
 	-- procedurally construct config UI
 	for key, entry in pairs(NTConfig.Entries) do
@@ -190,12 +187,12 @@ local function ConstructUI(parent)
 				OnChanged()
 			end
 		elseif entry.type == "category" then
-			-- visual separation
+			-- Change visual separation to subheader
 			GUI.TextBlock(
-				GUI.RectTransform(Vector2(1, 0.05), list.Content.RectTransform),
+				GUI.RectTransform(Vector2(1, 0.10), list.Content.RectTransform),
 				entry.name,
-				Color(255, 255, 255),
-				nil,
+				Color(255, 255, 237),
+				GUI.GUIStyle.SubHeadingFont,
 				GUI.Alignment.Center,
 				true,
 				nil,
@@ -203,18 +200,6 @@ local function ConstructUI(parent)
 			)
 		end
 	end
-
-	--empty space as last tickbox was getting cutoff
-	GUI.TextBlock(
-		GUI.RectTransform(Vector2(1, 0.05), list.Content.RectTransform),
-		"",
-		Color(255, 255, 255),
-		nil,
-		GUI.Alignment.Center,
-		true,
-		nil,
-		Color(0, 0, 0)
-	)
 
 	if Game.IsMultiplayer and not Game.Client.HasPermission(ClientPermissions.ManageSettings) then
 		for guicomponent in list.GetAllChildren() do

--- a/Neurotrauma/Lua/Scripts/Client/easysettings.lua
+++ b/Neurotrauma/Lua/Scripts/Client/easysettings.lua
@@ -50,15 +50,37 @@ easySettings.AddMenu = function(name, onOpen)
 	table.insert(easySettings.Settings, { Name = name, OnOpen = onOpen })
 end
 
+-- Overhauled Config GUI
 easySettings.BasicList = function(parent, size)
-	local menuContent = GUI.Frame(GUI.RectTransform(size or Vector2(0.3, 0.6), parent.RectTransform, GUI.Anchor.Center))
-	local menuList = GUI.ListBox(GUI.RectTransform(Vector2(1, 0.95), menuContent.RectTransform, GUI.Anchor.TopCenter))
+    -- Menu Frame
+    local menuContent = GUI.Frame(GUI.RectTransform(size or Vector2(0.4, 0.7), parent.RectTransform, GUI.Anchor.Center), "GUIFrame")
 
-	easySettings.SaveButton(menuContent)
-	easySettings.CloseButton(menuContent)
-	easySettings.ResetButton(menuContent)
+    -- Main Layout
+    local mainLayout = GUI.LayoutGroup(GUI.RectTransform(Vector2(0.95, 0.95), menuContent.RectTransform, GUI.Anchor.Center, GUI.Pivot.Center), false)
 
-	return menuList
+    -- Background 
+    local configBackground = GUI.Frame(GUI.RectTransform(Vector2(1, 0.95), mainLayout.RectTransform), "InnerFrame")
+
+    -- Shrink Inner layout 
+    local innerLayout = GUI.LayoutGroup(GUI.RectTransform(Vector2(0.95, 0.95), configBackground.RectTransform, GUI.Anchor.TopCenter), false)
+
+    -- Title block
+    local title = GUI.TextBlock(GUI.RectTransform(Vector2(1, 0.07), innerLayout.RectTransform), "Neurotrauma Config Settings", nil, GUI.GUIStyle.LargeFont)
+    title.TextAlignment = GUI.Alignment.TopCenter
+
+    -- Setting list
+    local menuList = GUI.ListBox(GUI.RectTransform(Vector2(1, 0.97), innerLayout.RectTransform))
+    menuList.Padding = Vector4(10, 15, 10, 10)
+    menuList.UpdateDimensions()
+
+    -- Button row
+    local buttonRow = GUI.LayoutGroup(GUI.RectTransform(Vector2(1, 0.1), mainLayout.RectTransform), true)
+    buttonRow.RelativeSpacing = 0.02
+    easySettings.SaveButton(buttonRow)
+    easySettings.CloseButton(buttonRow)
+    easySettings.ResetButton(buttonRow)
+
+    return menuList
 end
 
 easySettings.TickBox = function(parent, text, onSelected, state)

--- a/Neurotrauma/Lua/Scripts/Client/easysettings.lua
+++ b/Neurotrauma/Lua/Scripts/Client/easysettings.lua
@@ -111,7 +111,7 @@ end
 --save and exit
 easySettings.SaveButton = function(parent)
 	local button = GUI.Button(
-		GUI.RectTransform(Vector2(0.33, 0.05), parent.RectTransform, GUI.Anchor.BottomLeft),
+		GUI.RectTransform(Vector2(0.32, 0.05), parent.RectTransform, GUI.Anchor.BottomLeft),
 		"Save and Exit",
 		GUI.Alignment.Center,
 		"GUIButton"
@@ -132,7 +132,7 @@ end
 --discard and exit
 easySettings.CloseButton = function(parent)
 	local button = GUI.Button(
-		GUI.RectTransform(Vector2(0.33, 0.05), parent.RectTransform, GUI.Anchor.BottomCenter),
+		GUI.RectTransform(Vector2(0.32, 0.05), parent.RectTransform, GUI.Anchor.BottomCenter),
 		"Discard and Exit",
 		GUI.Alignment.Center,
 		"GUIButton"
@@ -149,7 +149,7 @@ end
 --reset and exit
 easySettings.ResetButton = function(parent)
 	local button = GUI.Button(
-		GUI.RectTransform(Vector2(0.33, 0.05), parent.RectTransform, GUI.Anchor.BottomRight),
+		GUI.RectTransform(Vector2(0.32, 0.05), parent.RectTransform, GUI.Anchor.BottomRight),
 		"Reset Config",
 		GUI.Alignment.Center,
 		"GUIButton"


### PR DESCRIPTION
As per [issue](https://github.com/OlegBSTU/Neurotrauma/issues/67#issue-3014801708), suggested rework for the Neurotrauma & Neurotrauma Addon setting config GUI.

Tweaked the way expansion / addon names were made, allowing for greater clarity:

![image](https://github.com/user-attachments/assets/688f3717-92a1-44a2-b3b6-496ba932a7c5)

Made the UI a bit taller and wider, to account for the amount of options and to decrease scrolling. Likewise, decreased some spacing between texts that was unnecessary. No sliders were added, as they actually decrease ease of access.

Added multiple layers of customization for possible future edits.

Fixed buttons overlapping a bit with the actual settings box, giving them a bit more space and clearer separation.

Added a title header, just cause.

Built entirely upon earlier system, it remains modular and does not conflict. Only added upon the old system.

**Before:**

![image](https://github.com/user-attachments/assets/e89eaa95-749b-4c6b-8a33-0d6d648518d7)

**After:**

![image](https://github.com/user-attachments/assets/2d42001d-f5d8-469d-a84f-0e79228551ee)