### PR TITLE
Alien Blood buff and vanilla talent changes

### DIFF
--- a/Neurotrauma/Localization/English/English.xml
+++ b/Neurotrauma/Localization/English/English.xml
@@ -752,6 +752,9 @@ Can give blood to: AB+</entitydescription.abpluscard>
 <!-- misc -->
 <roomname.surgical>Surgical</roomname.surgical>
 
+<!-- Talents -->
+<talentdescription.itemgiveslessaffliction>Administering ‖color:gui.orange‖Alien Blood‖end‖ gives [amount]% less ‖color:gui.orange‖Psychosis‖end‖ and [amount2]% less ‖color:gui.orange‖Hemotransfusion Shock‖end‖.</talentdescription.itemgiveslessaffliction>
+
 <!-- /// Loading Screen Tips /// -->
 
 <loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Non-medical personnel can treat cardiac arrest with the use of adrenaline or an AutoPulse.</loadingscreentip>

--- a/Neurotrauma/Xml/Items/Override.xml
+++ b/Neurotrauma/Xml/Items/Override.xml
@@ -170,14 +170,14 @@
                     <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
                 </StatusEffect>
 
-                <StatusEffect statuseffecttags="medical" type="OnSuccess" target="UseTarget, This" duration="1">
+                <StatusEffect statuseffecttags="medical" type="OnSuccess" target="UseTarget, This" duration="1" multiplyafflictionsbymaxvitality="true">
                     <ReduceAffliction identifier="bloodloss" amount="20" />
                     <Affliction identifier="hemotransfusionshock" amount="100"/>
                     <Affliction identifier="psychosis" amount="60" />
                     <Affliction identifier="bloodpressure" amount="15" />
                 </StatusEffect>
 
-                <StatusEffect statuseffecttags="medical" type="OnFailure" target="UseTarget, This" duration="1">
+                <StatusEffect statuseffecttags="medical" type="OnFailure" target="UseTarget, This" duration="1" multiplyafflictionsbymaxvitality="true">
                     <ReduceAffliction identifier="bloodloss" amount="20" />
                     <Affliction identifier="hemotransfusionshock" amount="100"/>
                     <Affliction identifier="psychosis" amount="60" />

--- a/Neurotrauma/Xml/Items/Override.xml
+++ b/Neurotrauma/Xml/Items/Override.xml
@@ -170,18 +170,18 @@
                     <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
                 </StatusEffect>
 
-                <StatusEffect statuseffecttags="medical" type="OnSuccess" target="UseTarget, This" duration="15">
-                    <ReduceAffliction identifier="bloodloss" amount="1" />
-                    <Affliction identifier="hemotransfusionshock" amount="6.6"/>
-                    <Affliction identifier="psychosis" amount="4" />
-                    <Affliction identifier="organdamage" amount="0.25" />
+                <StatusEffect statuseffecttags="medical" type="OnSuccess" target="UseTarget, This" duration="1">
+                    <ReduceAffliction identifier="bloodloss" amount="15" />
+                    <Affliction identifier="hemotransfusionshock" amount="100"/>
+                    <Affliction identifier="psychosis" amount="60" />
+                    <Affliction identifier="bloodpressure" amount="15" />
                 </StatusEffect>
 
-                <StatusEffect statuseffecttags="medical" type="OnFailure" target="UseTarget, This" duration="15">
-                    <ReduceAffliction identifier="bloodloss" amount="0.5" />
-                    <Affliction identifier="hemotransfusionshock" amount="6.6"/>
-                    <Affliction identifier="psychosis" amount="4" />
-                    <Affliction identifier="organdamage" amount="0.50" />
+                <StatusEffect statuseffecttags="medical" type="OnFailure" target="UseTarget, This" duration="1">
+                    <ReduceAffliction identifier="bloodloss" amount="15" />
+                    <Affliction identifier="hemotransfusionshock" amount="100"/>
+                    <Affliction identifier="psychosis" amount="60" />
+                    <Affliction identifier="bloodpressure" amount="15" />
                 </StatusEffect>
 
                 <StatusEffect type="OnBroken" target="This">
@@ -189,7 +189,7 @@
                 </StatusEffect>
             </Holdable>
 
-            <SkillRequirementHint identifier="medical" level="40"/>
+            <SkillRequirementHint identifier="medical" level="55"/>
         </Item>
 
         <Item name="" identifier="antibloodloss1" category="Medical" maxstacksize="32" maxstacksizecharacterinventory="8" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,petfood1,petfood2,petfood3" useinhealthinterface="true" description="" scale="0.5" impactsoundtag="impact_soft">

--- a/Neurotrauma/Xml/Items/Override.xml
+++ b/Neurotrauma/Xml/Items/Override.xml
@@ -164,24 +164,24 @@
             <Body width="30" height="55" density="11" />
 
             <Holdable canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" holdangle="10" handle1="0,0" msg="ItemMsgPickUpSelect">
-                <RequiredSkill identifier="medical" level="40"/>
+                <RequiredSkill identifier="medical" level="55"/>
 
                 <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true">
                     <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
                 </StatusEffect>
 
-                <StatusEffect statuseffecttags="medical" multiplyafflictionsbymaxvitality="true" type="OnSuccess" target="UseTarget, This" duration="15.0">
-                    <Affliction identifier="organdamage" amount="0.25"/>
+                <StatusEffect statuseffecttags="medical" type="OnSuccess" target="UseTarget, This" duration="15">
+                    <ReduceAffliction identifier="bloodloss" amount="1" />
                     <Affliction identifier="hemotransfusionshock" amount="6.6"/>
-                    <ReduceAffliction identifier="bloodloss" amount="0.5"/>
-                    <Affliction identifier="psychosis" amount="3" />
+                    <Affliction identifier="psychosis" amount="4" />
+                    <Affliction identifier="organdamage" amount="0.25" />
                 </StatusEffect>
 
-                <StatusEffect statuseffecttags="medical" multiplyafflictionsbymaxvitality="true" type="OnFailure" target="UseTarget, This" duration="15.0">
-                    <Affliction identifier="organdamage" amount="0.5"/>
+                <StatusEffect statuseffecttags="medical" type="OnFailure" target="UseTarget, This" duration="15">
+                    <ReduceAffliction identifier="bloodloss" amount="0.5" />
                     <Affliction identifier="hemotransfusionshock" amount="6.6"/>
-                    <ReduceAffliction identifier="bloodloss" amount="0.5"/>
-                    <Affliction identifier="psychosis" amount="3" />
+                    <Affliction identifier="psychosis" amount="4" />
+                    <Affliction identifier="organdamage" amount="0.50" />
                 </StatusEffect>
 
                 <StatusEffect type="OnBroken" target="This">

--- a/Neurotrauma/Xml/Items/Override.xml
+++ b/Neurotrauma/Xml/Items/Override.xml
@@ -171,14 +171,14 @@
                 </StatusEffect>
 
                 <StatusEffect statuseffecttags="medical" type="OnSuccess" target="UseTarget, This" duration="1">
-                    <ReduceAffliction identifier="bloodloss" amount="15" />
+                    <ReduceAffliction identifier="bloodloss" amount="20" />
                     <Affliction identifier="hemotransfusionshock" amount="100"/>
                     <Affliction identifier="psychosis" amount="60" />
                     <Affliction identifier="bloodpressure" amount="15" />
                 </StatusEffect>
 
                 <StatusEffect statuseffecttags="medical" type="OnFailure" target="UseTarget, This" duration="1">
-                    <ReduceAffliction identifier="bloodloss" amount="15" />
+                    <ReduceAffliction identifier="bloodloss" amount="20" />
                     <Affliction identifier="hemotransfusionshock" amount="100"/>
                     <Affliction identifier="psychosis" amount="60" />
                     <Affliction identifier="bloodpressure" amount="15" />

--- a/Neurotrauma/Xml/Items/Override.xml
+++ b/Neurotrauma/Xml/Items/Override.xml
@@ -174,14 +174,14 @@
                     <ReduceAffliction identifier="bloodloss" amount="20" />
                     <Affliction identifier="hemotransfusionshock" amount="100"/>
                     <Affliction identifier="psychosis" amount="60" />
-                    <Affliction identifier="bloodpressure" amount="15" />
+                    <Affliction identifier="bloodpressure" amount="20" />
                 </StatusEffect>
 
                 <StatusEffect statuseffecttags="medical" type="OnFailure" target="UseTarget, This" duration="1" multiplyafflictionsbymaxvitality="true">
                     <ReduceAffliction identifier="bloodloss" amount="20" />
                     <Affliction identifier="hemotransfusionshock" amount="100"/>
                     <Affliction identifier="psychosis" amount="60" />
-                    <Affliction identifier="bloodpressure" amount="15" />
+                    <Affliction identifier="bloodpressure" amount="20" />
                 </StatusEffect>
 
                 <StatusEffect type="OnBroken" target="This">

--- a/Neurotrauma/Xml/Talents.xml
+++ b/Neurotrauma/Xml/Talents.xml
@@ -1,0 +1,55 @@
+<Talents>
+    <Override>
+        <!-- Vanilla talents override -->
+
+        <!-- Bloody Business -->
+        <Talent identifier="bloodybusiness">
+            <Icon texture="Content/UI/TalentsIcons3.png" sheetindex="1,4" sheetelementsize="128,128"/>
+            <Description tag="talentdescription.itemgiveslessaffliction" >
+                <Replace tag="[amount]" value="50" color="gui.green"/>
+                <Replace tag="[amount2]" value="95" color="gui.green"/>
+            </Description>
+            <Description tag="talentdescription.bloodybusiness">
+                <Replace tag="[item]" value="entityname.alienblood" color="gui.orange"/>
+            </Description>
+            <AbilityGroupEffect abilityeffecttype="OnApplyTreatment">
+                <Conditions>
+                    <AbilityConditionItem identifiers="alienblood" />
+                </Conditions>
+                <Abilities>
+                    <CharacterAbilityApplyStatusEffects>
+                        <StatusEffects>
+                            <!-- counter half of the psychosis applied by alien blood -->
+                            <!-- also counter most of the hemo shock -->
+                            <!-- this still causes approximately 5% bloodloss and 2.5% organ damage -->
+                            <StatusEffect tags="medical" type="OnAbility" target="UseTarget" duration="1.0">
+                                <ReduceAffliction identifier="psychosis" amount="30" />
+                                <ReduceAffliction identifier="hemotransfusionshock" amount="95" />
+                            </StatusEffect>
+                        </StatusEffects>
+                    </CharacterAbilityApplyStatusEffects>
+                </Abilities>
+            </AbilityGroupEffect>
+            <AbilityGroupEffect abilityeffecttype="OnLootCharacter">
+                <Conditions>
+                    <AbilityConditionCharacter targettype="Monster">
+                        <Conditional IsMachine="false" />
+                        <Conditional IsHusk="false" />
+                        <Conditional maxhealth="gt 300"/>
+                    </AbilityConditionCharacter>
+                    <AbilityConditionCharacterNotLooted identifier="bloodybusiness" />
+                </Conditions>
+                <Abilities>
+                    <CharacterAbilityApplyStatusEffects>
+                        <StatusEffects>
+                            <StatusEffect type="OnAbility" target="UseTarget" spawnitemrandomly="true" >
+                                <SpawnItem identifiers="alienblood" spawnposition="ThisInventory" />
+                            </StatusEffect>
+                        </StatusEffects>
+                    </CharacterAbilityApplyStatusEffects>
+                    <CharacterAbilityMarkAsLooted identifier="bloodybusiness"/>
+                </Abilities>
+            </AbilityGroupEffect>
+        </Talent>
+    </Override>
+</Talents>

--- a/Neurotrauma/filelist.xml
+++ b/Neurotrauma/filelist.xml
@@ -20,6 +20,7 @@
   <Other file="%ModDir%/Images/Human/Human_male_mask.png" />
 
   <Afflictions  file="%ModDir%/Xml/Afflictions.xml" />
+  <Talents      file="%ModDir%/Xml/Talents.xml"/>
   <Item         file="%ModDir%/Xml/Items/Blood/BloodPacks.xml" />
   <Item         file="%ModDir%/Xml/Items/Blood/DonorCard.xml" />
   <Item         file="%ModDir%/Xml/Items/Blood/Gear.xml" />


### PR DESCRIPTION
Building off of baro unstable's alien blood changes (higher skill check, more psychosis), overall buff to item. Changes the vanilla Bloody Business talent to "work" with NT alien blood, making it a functional medical item.

List of changes:
- Alien blood applies all of its effects over 1 second, so it feels more like blood packs, and so that applying streptokinase 5 seconds after using alien blood on yourself doesn't get you killed (the long duration made the item unintuitive)
- Reduces bloodloss by 20%, increases psychosis by 60%, hemoshock by 100%, blood pressure by 20%
- Medical skill check is 55
- Bloody Business changes alien blood's psychosis gain to 30%, and hemoshock to 5%
- With Bloody Business, alien blood restores approximately 15% bloodloss in total and 2.5% to all organ damage is gained, due to the 5% hemotransfusion shock
- Updated Bloody Business text (English)

Why does alien blood sound so strong with the Bloody Business talent? Its competition is the Gene Splicer talent which is unanimously more popular.