### PR TITLE
Increase traumatic head amputation threshold

### DIFF
--- a/Neurotrauma/Lua/Scripts/Server/ondamaged.lua
+++ b/Neurotrauma/Lua/Scripts/Server/ondamaged.lua
@@ -263,7 +263,7 @@ NT.OnDamagedMethods.explosiondamage = function(character, strength, limbtype)
 		then
 			HF.AddAffliction(character, "n_fracture", 5)
 		end
-		if strength >= 25 and HF.Chance(0.25) then
+		if strength >= 100 and HF.Chance(0.25) then
 			-- drop previously held item
 			local previtem = HF.GetHeadWear(character)
 			if previtem ~= nil then

--- a/Neurotrauma/Lua/Scripts/Server/ondamaged.lua
+++ b/Neurotrauma/Lua/Scripts/Server/ondamaged.lua
@@ -263,7 +263,7 @@ NT.OnDamagedMethods.explosiondamage = function(character, strength, limbtype)
 		then
 			HF.AddAffliction(character, "n_fracture", 5)
 		end
-		if strength >= 100 and HF.Chance(0.25) then
+		if strength >= 75 and HF.Chance(0.25) then
 			-- drop previously held item
 			local previtem = HF.GetHeadWear(character)
 			if previtem ~= nil then


### PR DESCRIPTION
As an unintended side effect of the [head getting explosiondamage multiplier](https://github.com/OlegBSTU/Neurotrauma/pull/61), it is now very easy to get a head amputation after taking minimal damage. This change increases the damage threshold to ~~100~~ 75, making the affliction once again more of an easter egg and not an rng instakill.