### PR TITLE
Improved surgery toolbox kit text

### DIFF
--- a/Neurotrauma/Localization/English/English.xml
+++ b/Neurotrauma/Localization/English/English.xml
@@ -235,8 +235,9 @@ Can give blood to: AB+</entitydescription.abpluscard>
 <entityname.surgerytoolbox>Surgery toolbox</entityname.surgerytoolbox>
 <entitydescription.surgerytoolbox>Can store many small items that are used during surgery</entitydescription.surgerytoolbox>
 
-<entityname.surgerytoolboxset>Surgery toolbox (kit) </entityname.surgerytoolboxset>
+<entityname.surgerytoolboxset>Surgery toolbox</entityname.surgerytoolboxset>
 <entitydescription.surgerytoolboxset>Can store many small items that are used during surgery</entitydescription.surgerytoolboxset>
+<displayname.surgeryset>[itemname] (kit)</displayname.surgeryset>
 
 <entityname.organcrate>Refrigerated crate</entityname.organcrate> 
 <entitydescription.organcrate>A place to store your precious transplant-ready organs</entitydescription.organcrate>

--- a/Neurotrauma/Localization/French/French.xml
+++ b/Neurotrauma/Localization/French/French.xml
@@ -229,8 +229,9 @@ Peut donner du sang à: AB+</entitydescription.abpluscard>
 <entityname.surgerytoolbox>Boîte à outils chirurgicaux</entityname.surgerytoolbox> 
 <entitydescription.surgerytoolbox>Peut stocker de nombreux petits objets utilisés lors d'une chirurgie.</entitydescription.surgerytoolbox>
 
-<entityname.surgerytoolboxset>Boîte à outils chirurgicaux (l'ensemble)</entityname.surgerytoolboxset> 
+<entityname.surgerytoolboxset>Boîte à outils chirurgicaux</entityname.surgerytoolboxset> 
 <entitydescription.surgerytoolboxset>Peut stocker de nombreux petits objets utilisés lors d'une chirurgie.</entitydescription.surgerytoolboxset>
+<displayname.surgeryset>[itemname] (l'ensemble)</displayname.surgeryset>
 
 <entityname.organcrate>Caisse réfrigérée</entityname.organcrate> 
 <entitydescription.organcrate>Une caisse pour entreposer vos précieux organes prêts à être greffés.</entitydescription.organcrate>

--- a/Neurotrauma/Localization/German/German.xml
+++ b/Neurotrauma/Localization/German/German.xml
@@ -240,8 +240,9 @@ Kann spenden an: AB+</entitydescription.abpluscard>
 <entityname.surgerytoolbox>Chirurgische Werkzeugkiste</entityname.surgerytoolbox>
 <entitydescription.surgerytoolbox>Kann viele kleine Gegenstände aufbewahren, die während einer Operation verwendet werden.</entitydescription.surgerytoolbox>
 
-<entityname.surgerytoolboxset>Chirurgische Werkzeugkiste (der sachgesamtheit)</entityname.surgerytoolboxset>
+<entityname.surgerytoolboxset>Chirurgische Werkzeugkiste</entityname.surgerytoolboxset>
 <entitydescription.surgerytoolboxset>Kann viele kleine Gegenstände aufbewahren, die während einer Operation verwendet werden.</entitydescription.surgerytoolboxset>
+<displayname.surgeryset>[itemname] (der sachgesamtheit)</displayname.surgeryset>
 
 <entityname.organcrate>Tiefkühlkoffer</entityname.organcrate> 
 <entitydescription.organcrate>Wird genutzt um Organe zu lagern und am Leben zu halten.</entitydescription.organcrate>

--- a/Neurotrauma/Localization/Korean/Korean.xml
+++ b/Neurotrauma/Localization/Korean/Korean.xml
@@ -178,8 +178,9 @@
 <entitydescription.medtoolbox>약 및 의료기구를 보관할 수 있습니다.</entitydescription.medtoolbox>
 <entityname.surgerytoolbox>수술도구 보관함</entityname.surgerytoolbox>
 <entitydescription.surgerytoolbox>수술 중 사용하는 많은 작은 물건을 보관할 수 있습니다.</entitydescription.surgerytoolbox>
-<entityname.surgerytoolboxset>수술도구 보관함 (전부)</entityname.surgerytoolboxset>
+<entityname.surgerytoolboxset>수술도구 보관함</entityname.surgerytoolboxset>
 <entitydescription.surgerytoolboxset>수술 중 사용하는 많은 작은 물건을 보관할 수 있습니다.</entitydescription.surgerytoolboxset>
+<displayname.surgeryset>[itemname] (전부)</displayname.surgeryset>
 
 <entityname.organcrate>저온 상자</entityname.organcrate>
 <entitydescription.organcrate>소중한 이식용 장기를 보관하는 곳</entitydescription.organcrate>

--- a/Neurotrauma/Localization/Polish/Polish.xml
+++ b/Neurotrauma/Localization/Polish/Polish.xml
@@ -231,8 +231,9 @@ Biorcy: AB+</entitydescription.abpluscard>
 <entityname.surgerytoolbox>Przybornik chirurgiczny</entityname.surgerytoolbox> 
 <entitydescription.surgerytoolbox>Pomieści wiele małych narzędzi chirurgicznych.</entitydescription.surgerytoolbox>
 
-<entityname.surgerytoolboxset>Przybornik chirurgiczny (zestaw)</entityname.surgerytoolboxset> 
+<entityname.surgerytoolboxset>Przybornik chirurgiczny</entityname.surgerytoolboxset> 
 <entitydescription.surgerytoolboxset>Pomieści wiele małych narzędzi chirurgicznych.</entitydescription.surgerytoolboxset>
+<displayname.surgeryset>[itemname] (zestaw)</displayname.surgeryset>
 
 <entityname.organcrate>Skrzynia chłodnicza</entityname.organcrate> 
 <entitydescription.organcrate>Miejsce do przechowywania cennych narządów gotowych do przeszczepu.</entitydescription.organcrate>

--- a/Neurotrauma/Localization/Portuguese/Portuguese.xml
+++ b/Neurotrauma/Localization/Portuguese/Portuguese.xml
@@ -162,8 +162,9 @@ Pode dar sangue para: AB+</entitydescription.abpluscard>
 <entitydescription.medtoolbox>Pode armazenar medicamentos e instrumentos médicos.</entitydescription.medtoolbox>
 <entityname.surgerytoolbox>Caixa de Equipamento Cirúrgico</entityname.surgerytoolbox> 
 <entitydescription.surgerytoolbox>Pode armazenar muitos itens pequenos que são usados ​​durante uma cirurgia.</entitydescription.surgerytoolbox>
-<entityname.surgerytoolboxset>Caixa de Equipamento Cirúrgico (kit)</entityname.surgerytoolboxset> 
+<entityname.surgerytoolboxset>Caixa de Equipamento Cirúrgico</entityname.surgerytoolboxset> 
 <entitydescription.surgerytoolboxset>Pode armazenar muitos itens pequenos que são usados ​​durante uma cirurgia.</entitydescription.surgerytoolboxset>
+<displayname.surgeryset>[itemname] (kit)</displayname.surgeryset>
 <entityname.organcrate>Caixa Refrigerada</entityname.organcrate> 
 <entitydescription.organcrate>Um lugar para armazenar seus preciosos órgãos, prontos para transplante... né?</entitydescription.organcrate>
 <entityname.organtoolbox>Contêiner Refrigerado</entityname.organtoolbox> 

--- a/Neurotrauma/Localization/Russian/Russian.xml
+++ b/Neurotrauma/Localization/Russian/Russian.xml
@@ -223,8 +223,9 @@
 <entityname.surgerytoolbox>Ящик для хирургических инструментов</entityname.surgerytoolbox>
 <entitydescription.surgerytoolbox>Может вмещать в себя маленькие предметы для хирургии</entitydescription.surgerytoolbox> 
 
-<entityname.surgerytoolboxset>Ящик для хирургических инструментов (набор)</entityname.surgerytoolboxset>
+<entityname.surgerytoolboxset>Ящик для хирургических инструментов</entityname.surgerytoolboxset>
 <entitydescription.surgerytoolboxset>Может вмещать в себя маленькие предметы для хирургии</entitydescription.surgerytoolboxset> 
+<displayname.surgeryset>[itemname] (набор)</displayname.surgeryset>
 
 <entityname.organcrate>Холодильный ящик</entityname.organcrate>
 <entitydescription.organcrate>Место для хранения ваших драгоценных готовых к трансплантации органов</entitydescription.organcrate>

--- a/Neurotrauma/Localization/Spanish/Spanish.xml
+++ b/Neurotrauma/Localization/Spanish/Spanish.xml
@@ -228,8 +228,9 @@ Puede dar sangre a: AB+</entitydescription.abpluscard>
 <entityname.surgerytoolbox>Caja de herramientas de cirugía</entityname.surgerytoolbox> 
 <entitydescription.surgerytoolbox>Puede almacenar muchos artículos pequeños que se usan durante la cirugía.</entitydescription.surgerytoolbox>
 
-<entityname.surgerytoolboxset>Caja de herramientas de cirugía (equipo)</entityname.surgerytoolboxset> 
+<entityname.surgerytoolboxset>Caja de herramientas de cirugía</entityname.surgerytoolboxset> 
 <entitydescription.surgerytoolboxset>Puede almacenar muchos artículos pequeños que se usan durante la cirugía.</entitydescription.surgerytoolboxset>
+<displayname.surgeryset>[itemname] (equipo)</displayname.surgeryset>
 
 <entityname.organcrate>Caja refrigerada</entityname.organcrate> 
 <entitydescription.organcrate>Un lugar para almacenar sus preciados órganos listos para trasplante.</entitydescription.organcrate>

--- a/Neurotrauma/Localization/Turkish/Turkish.xml
+++ b/Neurotrauma/Localization/Turkish/Turkish.xml
@@ -232,8 +232,9 @@ Tüm Kan Gruplarına Kan Verebilir</entitydescription.ominuscard>
 <entityname.surgerytoolbox>Ameliyat Alet Çantası</entityname.surgerytoolbox>
 <entitydescription.surgerytoolbox>Ameliyatta kullanılan küçük aletleri taşımaya yarar.</entitydescription.surgerytoolbox>
 
-<entityname.surgerytoolboxset>Ameliyat Alet Çantası (kit)</entityname.surgerytoolboxset>
+<entityname.surgerytoolboxset>Ameliyat Alet Çantası</entityname.surgerytoolboxset>
 <entitydescription.surgerytoolboxset>Ameliyatta kullanılan küçük aletleri taşımaya yarar.</entitydescription.surgerytoolboxset>
+<displayname.surgeryset>[itemname] (kit)</displayname.surgeryset>
 
 <entityname.organcrate>Soğutma Kapasiteli Kasa</entityname.organcrate>
 <entitydescription.organcrate>Soğutmaya ihtiyaç duyan organları ve jel buz torbalarını taşır.</entitydescription.organcrate>

--- a/Neurotrauma/Xml/Items/Containers.xml
+++ b/Neurotrauma/Xml/Items/Containers.xml
@@ -164,7 +164,7 @@
             <Item identifier="steel" />
         </Deconstruct>
        
-        <Fabricate suitablefabricators="fabricator" requiredtime="20">
+        <Fabricate suitablefabricators="fabricator" displayname="surgeryset" requiredtime="20">
             <RequiredSkill identifier="mechanical" level="20" />
             <Item identifier="steel" amount="3"/>
             <Item identifier="zinc" amount="2"/>


### PR DESCRIPTION
The "Surgery toolbox (kit)" displays this name even after it is crafted, which is not ideal, as you now carry a toolbox which looks the same as any other toolbox but is for some reason suffixed with "(kit)". This PR makes the toolbox itself have the same name as the empty toolbox, while retaining the "(kit)" in the fabricator UI. Updated for all languages.

![image](https://github.com/user-attachments/assets/727e3c69-7796-4625-bab8-cdb5c3db0d3e)
![image](https://github.com/user-attachments/assets/e21a8fdd-3ea3-4ec1-9ba7-bdcce384f0b0)
