### PR TITLE
Bloody business fix

### DIFF
--- a/Neurotrauma/Localization/English/English.xml
+++ b/Neurotrauma/Localization/English/English.xml
@@ -760,7 +760,7 @@ Can give blood to: AB+</entitydescription.abpluscard>
 <roomname.surgical>Surgical</roomname.surgical>
 
 <!-- Talents -->
-<talentdescription.itemgiveslessaffliction>Administering ‖color:gui.orange‖Alien Blood‖end‖ gives [amount]% less ‖color:gui.orange‖Psychosis‖end‖ and ‖color:gui.green‖95%‖end‖ less ‖color:gui.orange‖Hemotransfusion Shock‖end‖.</talentdescription.itemgiveslessaffliction>
+<talentdescription.itemgiveslessaffliction>Administering ‖color:gui.orange‖Alien Blood‖end‖ gives [amount]% less ‖color:gui.orange‖Psychosis‖end‖ and ‖color:gui.green‖90%‖end‖ less ‖color:gui.orange‖Hemotransfusion Shock‖end‖.</talentdescription.itemgiveslessaffliction>
 
 <!-- /// Loading Screen Tips /// -->
 

--- a/Neurotrauma/Localization/English/English.xml
+++ b/Neurotrauma/Localization/English/English.xml
@@ -760,7 +760,7 @@ Can give blood to: AB+</entitydescription.abpluscard>
 <roomname.surgical>Surgical</roomname.surgical>
 
 <!-- Talents -->
-<talentdescription.itemgiveslessaffliction>Administering ‖color:gui.orange‖Alien Blood‖end‖ gives [amount]% less ‖color:gui.orange‖Psychosis‖end‖ and [amount2]% less ‖color:gui.orange‖Hemotransfusion Shock‖end‖.</talentdescription.itemgiveslessaffliction>
+<talentdescription.itemgiveslessaffliction>Administering ‖color:gui.orange‖Alien Blood‖end‖ gives [amount]% less ‖color:gui.orange‖Psychosis‖end‖ and ‖color:gui.green‖95%‖end‖ less ‖color:gui.orange‖Hemotransfusion Shock‖end‖.</talentdescription.itemgiveslessaffliction>
 
 <!-- /// Loading Screen Tips /// -->
 

--- a/Neurotrauma/Xml/Items/Override.xml
+++ b/Neurotrauma/Xml/Items/Override.xml
@@ -170,18 +170,18 @@
                     <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
                 </StatusEffect>
 
-                <StatusEffect statuseffecttags="medical" type="OnSuccess" target="UseTarget, This" duration="1" multiplyafflictionsbymaxvitality="true">
+                <StatusEffect statuseffecttags="medical" type="OnSuccess" target="UseTarget, This" duration="1" multiplyafflictionsbymaxvitality="true" disabledeltatime="true">
                     <ReduceAffliction identifier="bloodloss" amount="20" />
                     <Affliction identifier="hemotransfusionshock" amount="100"/>
-                    <Affliction identifier="psychosis" amount="60" />
+                    <Affliction identifier="psychosis" amount="30" />
                     <Affliction identifier="bloodpressure" amount="20" />
                 </StatusEffect>
 
-                <StatusEffect statuseffecttags="medical" type="OnFailure" target="UseTarget, This" duration="1" multiplyafflictionsbymaxvitality="true">
-                    <ReduceAffliction identifier="bloodloss" amount="20" />
+                <StatusEffect statuseffecttags="medical" type="OnFailure" target="UseTarget, This" duration="1" multiplyafflictionsbymaxvitality="true" disabledeltatime="true">
+                    <ReduceAffliction identifier="bloodloss" amount="15" />
                     <Affliction identifier="hemotransfusionshock" amount="100"/>
-                    <Affliction identifier="psychosis" amount="60" />
-                    <Affliction identifier="bloodpressure" amount="20" />
+                    <Affliction identifier="psychosis" amount="30" />
+                    <Affliction identifier="bloodpressure" amount="15" />
                 </StatusEffect>
 
                 <StatusEffect type="OnBroken" target="This">

--- a/Neurotrauma/Xml/Items/Override.xml
+++ b/Neurotrauma/Xml/Items/Override.xml
@@ -170,14 +170,14 @@
                     <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
                 </StatusEffect>
 
-                <StatusEffect statuseffecttags="medical" type="OnSuccess" target="UseTarget, This" duration="1" multiplyafflictionsbymaxvitality="true" disabledeltatime="true">
+                <StatusEffect statuseffecttags="medical" type="OnSuccess" target="UseTarget" multiplyafflictionsbymaxvitality="true" disabledeltatime="true">
                     <ReduceAffliction identifier="bloodloss" amount="20" />
                     <Affliction identifier="hemotransfusionshock" amount="100"/>
                     <Affliction identifier="psychosis" amount="30" />
                     <Affliction identifier="bloodpressure" amount="20" />
                 </StatusEffect>
 
-                <StatusEffect statuseffecttags="medical" type="OnFailure" target="UseTarget, This" duration="1" multiplyafflictionsbymaxvitality="true" disabledeltatime="true">
+                <StatusEffect statuseffecttags="medical" type="OnFailure" target="UseTarget" multiplyafflictionsbymaxvitality="true" disabledeltatime="true">
                     <ReduceAffliction identifier="bloodloss" amount="15" />
                     <Affliction identifier="hemotransfusionshock" amount="100"/>
                     <Affliction identifier="psychosis" amount="30" />

--- a/Neurotrauma/Xml/Talents.xml
+++ b/Neurotrauma/Xml/Talents.xml
@@ -7,7 +7,6 @@
             <Icon texture="Content/UI/TalentsIcons3.png" sheetindex="1,4" sheetelementsize="128,128"/>
             <Description tag="talentdescription.itemgiveslessaffliction" >
                 <Replace tag="[amount]" value="50" color="gui.green"/>
-                <Replace tag="[amount2]" value="95" color="gui.green"/>
             </Description>
             <Description tag="talentdescription.bloodybusiness">
                 <Replace tag="[item]" value="entityname.alienblood" color="gui.orange"/>
@@ -22,8 +21,8 @@
                             <!-- counter half of the psychosis applied by alien blood -->
                             <!-- also counter most of the hemo shock -->
                             <!-- this still causes approximately 5% bloodloss and 2.5% organ damage -->
-                            <StatusEffect tags="medical" type="OnAbility" target="UseTarget" duration="1.0">
-                                <ReduceAffliction identifier="psychosis" amount="30" />
+                            <StatusEffect tags="medical" type="OnAbility" target="UseTarget" duration="1.0" multiplyafflictionsbymaxvitality="true" disabledeltatime="true">
+                                <ReduceAffliction identifier="psychosis" amount="15" />
                                 <ReduceAffliction identifier="hemotransfusionshock" amount="95" />
                             </StatusEffect>
                         </StatusEffects>

--- a/Neurotrauma/Xml/Talents.xml
+++ b/Neurotrauma/Xml/Talents.xml
@@ -21,9 +21,9 @@
                             <!-- counter half of the psychosis applied by alien blood -->
                             <!-- also counter most of the hemo shock -->
                             <!-- this still causes approximately 5% bloodloss and 2.5% organ damage -->
-                            <StatusEffect tags="medical" type="OnAbility" target="UseTarget" duration="1.0" multiplyafflictionsbymaxvitality="true" disabledeltatime="true">
+                            <StatusEffect tags="medical" type="OnAbility" target="UseTarget" multiplyafflictionsbymaxvitality="true" disabledeltatime="true">
                                 <ReduceAffliction identifier="psychosis" amount="15" />
-                                <ReduceAffliction identifier="hemotransfusionshock" amount="95" />
+                                <ReduceAffliction identifier="hemotransfusionshock" amount="90" />
                             </StatusEffect>
                         </StatusEffects>
                     </CharacterAbilityApplyStatusEffects>


### PR DESCRIPTION
Fixes the bloody business talent not working in pretty much every way possible. Also included is a minor rebalance. Less psychosis, more hemo shock. Duration of the item is now also instantaneous instead of 1 second, seems to work properly.