### PR TITLE
Error tracing for problematic HF.SetAfflictionLimb function

### DIFF
--- a/Neurotrauma/Lua/Scripts/helperfunctions.lua
+++ b/Neurotrauma/Lua/Scripts/helperfunctions.lua
@@ -1,5 +1,25 @@
 -- This file contains a bunch of useful functions that see heavy use in the other scripts.
 
+LuaUserData.RegisterType('Barotrauma.ModUtils+Logging') 
+local Logging = LuaUserData.CreateStatic('Barotrauma.ModUtils+Logging')
+
+local function TraceError(errorMessage)
+	if errorMessage then
+		errorMessage = "Neurotrauma Error: " .. errorMessage
+	else
+		errorMessage = "Neurotrauma Error"
+	end
+	--second argument means traceback level, 2 means we exclude topmoost aka this function
+	Logging.PrintError(debug.traceback(errorMessage, 2))
+end
+
+local LimbNames = {}
+for key, value in pairs(LimbType) do
+	LimbNames[value] = key
+end
+
+
+
 -- Neurotrauma functions
 
 function NT.DislocateLimb(character, limbtype, strength)
@@ -414,7 +434,21 @@ end
 
 -- the main "mess with afflictions" function
 function HF.SetAfflictionLimb(character, identifier, limbtype, strength, aggressor, prevstrength)
-	local prefab = AfflictionPrefab.Prefabs[identifier]
+	local _, prefab = AfflictionPrefab.Prefabs.TryGet(identifier)
+	if	not character or
+		not limbtype or
+		not prefab
+	then
+		TraceError(string.format("Can't apply affliction to character limb\ncharacter = %s, limbtype = %s, affliction = %s, strength = %s",
+			character and  tostring(character.Name) or "nil",
+			limbtype and LimbNames[limbtype] or limbtype or "nil",
+			prefab and string.format("%s (%s)", tostring(prefab.Name), tostring(prefab.Identifier)) or tostring(identifier) or "nil",
+			strength and string.format("%.3f", strength) or "nil"
+		))
+		return
+	end
+
+	
 	local resistance = character.CharacterHealth.GetResistance(prefab, limbtype)
 	if resistance >= 1 then
 		return


### PR DESCRIPTION
Shows arguments and full trace
<img width="717" height="165" alt="изображение" src="https://github.com/user-attachments/assets/1283fb43-98fd-4fc6-9b96-f1e353453bb1" />

In case some arguments are missing replaces them with nils, also works when called from other mods
<img width="640" height="125" alt="изображение" src="https://github.com/user-attachments/assets/e3bcd6a8-a6e9-4f17-95df-6bcb81001de2" />
