### PR TITLE
Put unconscious characters on beds

### DIFF
--- a/Neurotrauma/Localization/English/English.xml
+++ b/Neurotrauma/Localization/English/English.xml
@@ -792,6 +792,8 @@ Can give blood to: AB+</entitydescription.abpluscard>
 
 <!-- misc -->
 <roomname.surgical>Surgical</roomname.surgical>
+<ItemMsgPutInsideSelectKey>[[select]] Put inside</ItemMsgPutInsideSelectKey>
+<ItemMsgTakeOutSelectKey>[[select]] Take out</ItemMsgTakeOutSelectKey>
 
 <!-- Talents -->
 <talentdescription.itemgiveslessaffliction>Administering ‖color:gui.orange‖Alien Blood‖end‖ gives [amount]% less ‖color:gui.orange‖Psychosis‖end‖ and ‖color:gui.green‖90%‖end‖ less ‖color:gui.orange‖Hemotransfusion Shock‖end‖.</talentdescription.itemgiveslessaffliction>

--- a/Neurotrauma/Xml/Items/Etc.xml
+++ b/Neurotrauma/Xml/Items/Etc.xml
@@ -29,7 +29,7 @@
 
         <sprite texture="%ModDir%/Images/MedBayAssets.png" sourcerect="100,311,407,184" depth="0.53" premultiplyalpha="false" origin="0.5,0.5"/> 
 
-        <Controller allowingameediting="false" UserPos="0,-300" direction="Right" hidehud="false" canbeselected="true" selectkey="Select">
+        <Controller allowingameediting="false" UserPos="0,-300" direction="Right" hidehud="false" canbeselected="true" AllowPuttingInOtherCharacters="true" KickOutCharacterMsg="ItemMsgTakeOutSelectKey" putothercharactermsg="ItemMsgPutInsideSelectKey" SelectingKicksCharacterOut="true" AllowSelectingWhenSelectedByOther="false" selectkey="Select" forceusertostayattached="true">
             <limbposition limb="Head" position="-6,-10" allowusinglimb="true"/>
             <limbposition limb="Torso" position="104,0" allowusinglimb="true"/>
             <limbposition limb="Waist" position="244,-80" allowusinglimb="true"/>

--- a/Neurotrauma/Xml/Items/Override.xml
+++ b/Neurotrauma/Xml/Items/Override.xml
@@ -360,7 +360,7 @@
                 </StatusEffect>
             </ItemComponent>
 
-            <Controller allowingameediting="false" UserPos="0,-300" direction="Right" hidehud="false" canbeselected="true" noninteractablewhenflippedy="true" drawuserbehind="true">
+            <Controller allowingameediting="false" UserPos="0,-300" direction="Right" hidehud="false" canbeselected="true" noninteractablewhenflippedy="true" drawuserbehind="true" AllowPuttingInOtherCharacters="true" KickOutCharacterMsg="ItemMsgTakeOutSelectKey" putothercharactermsg="ItemMsgPutInsideSelectKey" SelectingKicksCharacterOut="true" AllowSelectingWhenSelectedByOther="false" selectkey="Select" forceusertostayattached="true">
                 <!-- don't allow laying in bed when wearing an exosuit -->
                 <RequiredItem items="deepdivinglarge" type="Picked" requireempty="true" />
                 <limbposition limb="Head" position="-6,-10" allowusinglimb="true"/>
@@ -410,7 +410,7 @@
             <Upgrade gameversion="0.12.0.0" noninteractable="false"/>
             <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1600,1760,384,264" depth="0.85" premultiplyalpha="false" origin="0.5,0.5"/>
 
-            <Controller UserPos="0,-300" direction="Right" hidehud="false" canbeselected="true" drawuserbehind="true" noninteractablewhenflippedy="true">
+            <Controller UserPos="0,-300" direction="Right" hidehud="false" canbeselected="true" drawuserbehind="true" noninteractablewhenflippedy="true" AllowPuttingInOtherCharacters="true" KickOutCharacterMsg="ItemMsgTakeOutSelectKey" putothercharactermsg="ItemMsgPutInsideSelectKey" SelectingKicksCharacterOut="true" AllowSelectingWhenSelectedByOther="false" selectkey="Select" forceusertostayattached="true">
                 <!-- don't allow laying in bed when wearing an exosuit -->
                 <RequiredItem items="deepdivinglarge" type="Picked" requireempty="true" />
                 <limbposition limb="Head" position="-26,-170"/>
@@ -446,7 +446,7 @@
             <DecorativeSprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1390,1126,320,160" depth="0.86" origin="0.5,0.5" offset="40,-95"/>
             <DecorativeSprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="1390,1126,320,160" depth="0.86" origin="0.5,0.5" offset="40,105"/>
 
-            <Controller UserPos="0,-300" direction="Right" hidehud="false" canbeselected="true" drawuserbehind="true" noninteractablewhenflippedy="true">
+            <Controller UserPos="0,-300" direction="Right" hidehud="false" canbeselected="true" drawuserbehind="true" noninteractablewhenflippedy="true" AllowPuttingInOtherCharacters="true" KickOutCharacterMsg="ItemMsgTakeOutSelectKey" putothercharactermsg="ItemMsgPutInsideSelectKey" SelectingKicksCharacterOut="true" AllowSelectingWhenSelectedByOther="false" selectkey="Select" forceusertostayattached="true">
                 <!-- don't allow laying in bed when wearing an exosuit -->
                 <RequiredItem items="deepdivinglarge" type="Picked" requireempty="true" />
                 <limbposition limb="Head" position="14,-300"/>
@@ -480,7 +480,7 @@
         <Item name="" identifier="opdeco_prisonbed" allowattachitems="true" width="384" height="96" texturescale="1.0,1.0" scale="0.5" category="Decorative">
             <sprite texture="Content/Map/Outposts/Art/Storage.png" sourcerect="864,1888,384,96" depth="0.98" premultiplyalpha="false" origin="0.5,0.5"/>
 
-            <Controller UserPos="0,-300" direction="Right" hidehud="false" issecondaryitem="true" canbeselected="true" noninteractablewhenflippedy="true" drawuserbehind="true">
+            <Controller UserPos="0,-300" direction="Right" hidehud="false" issecondaryitem="true" canbeselected="true" noninteractablewhenflippedy="true" drawuserbehind="true" AllowPuttingInOtherCharacters="true" KickOutCharacterMsg="ItemMsgTakeOutSelectKey" putothercharactermsg="ItemMsgPutInsideSelectKey" SelectingKicksCharacterOut="true" AllowSelectingWhenSelectedByOther="false" selectkey="Select" forceusertostayattached="true">
                 <!-- don't allow laying in bed when wearing an exosuit -->
                 <RequiredItem items="deepdivinglarge" type="Picked" requireempty="true" />
                 <limbposition limb="Head" position="-6,-10"/>
@@ -513,7 +513,7 @@
 
         <Item name="" identifier="bunk" width="173" height="129" category="Decorative">
             <sprite texture="Content/Map/MiscStructures.png" sourcerect="1416,1163,173,129" depth="0.85" origin="0.5,0.5" />
-            <Controller UserPos="0,-150" direction="Right" hidehud="false" issecondaryitem="true" canbeselected="true" drawuserbehind="true" noninteractablewhenflippedy="true">
+            <Controller UserPos="0,-150" direction="Right" hidehud="false" issecondaryitem="true" canbeselected="true" drawuserbehind="true" noninteractablewhenflippedy="true" AllowPuttingInOtherCharacters="true" KickOutCharacterMsg="ItemMsgTakeOutSelectKey" putothercharactermsg="ItemMsgPutInsideSelectKey" SelectingKicksCharacterOut="true" AllowSelectingWhenSelectedByOther="false" selectkey="Select" forceusertostayattached="true">
                 <limbposition limb="Head" position="-13,-85" />
                 <limbposition limb="Torso" position="42,-70" />
                 <limbposition limb="Waist" position="112,-80" />
@@ -538,7 +538,7 @@
 
         <Item name="" identifier="bunkwrecked" nameidentifier="bunk" width="173" height="129" category="Wrecked">
             <sprite texture="Content/Items/Shipwrecks/BackgroundStructuresWrecked.png" sourcerect="497,692,173,129" depth="0.88" origin="0.5,0.5" />
-            <Controller UserPos="0,-150" direction="Right" hidehud="false" canbeselected="true" drawuserbehind="true">
+            <Controller UserPos="0,-150" direction="Right" hidehud="false" canbeselected="true" drawuserbehind="true" AllowPuttingInOtherCharacters="true" KickOutCharacterMsg="ItemMsgTakeOutSelectKey" putothercharactermsg="ItemMsgPutInsideSelectKey" SelectingKicksCharacterOut="true" AllowSelectingWhenSelectedByOther="false" selectkey="Select" forceusertostayattached="true">
                 <limbposition limb="Head" position="-13,-85" />
                 <limbposition limb="Torso" position="42,-70" />
                 <limbposition limb="Waist" position="112,-80" />


### PR DESCRIPTION
XML from current unstable version (1.12.6.1) which allows putting unconscious or stunned characters in beds. This is a PR because vanilla will only allow putting unconscious characters in clown crates, deconstructors, and boarding pods.

The devices in the surgery table will work when a character is put on the table by force. This applies to all other code being run in the controller component.

A couple new lines were added to English file because the vanilla messages for putting or taking characters out of controllers is for the Use key only and it's better to keep the player habit of using left click to use beds instead.

There is some new minor jank involved. First, putting unconscious characters in the beds makes them look weird (they don't "lay" on it visually). Second, putting yourself in the beds no longer has a walking animation, you just teleport to the bed (this seems to be a [side effect of the system](https://discord.com/channels/103209684680323072/668819422919524352/1490390117683040466)). And finally, for some reason, laying yourself on the prison bed or regular bunk makes you crumple to the floor. I have no idea why this happens.