### PR TITLE
AlwaysStayConscious ability prevents unconsciousness & Implacable changes

### DIFF
--- a/Neurotrauma/Lua/Scripts/Server/humanupdate.lua
+++ b/Neurotrauma/Lua/Scripts/Server/humanupdate.lua
@@ -953,13 +953,13 @@ NT.Afflictions = {
 					NTC.GetSymptom(c.character, i)
 					or c.stats.stasis
 					or c.afflictions.brainremoved.strength > 0
-					or (not HF.HasAffliction(c.character, "implacable", 0.05) and (c.character.Vitality <= 0 or c.afflictions.hypoxemia.strength > 80))
 					or c.afflictions.cerebralhypoxia.strength > 100
 					or c.afflictions.coma.strength > 15
 					or c.afflictions.t_arterialcut.strength > 0
 					or c.afflictions.seizure.strength > 0.1
 					or c.afflictions.opiateoverdose.strength > 60
 				)
+				and not c.character.HasAbilityFlag(AbilityFlags.AlwaysStayConscious)
 			c.afflictions[i].strength = HF.BoolToNum(isUnconscious, 2)
 		end,
 	},

--- a/Neurotrauma/Lua/Scripts/Server/humanupdate.lua
+++ b/Neurotrauma/Lua/Scripts/Server/humanupdate.lua
@@ -958,6 +958,7 @@ NT.Afflictions = {
 					or c.afflictions.t_arterialcut.strength > 0
 					or c.afflictions.seizure.strength > 0.1
 					or c.afflictions.opiateoverdose.strength > 60
+					or c.character.Vitality <= 0
 				)
 				and not c.character.HasAbilityFlag(AbilityFlags.AlwaysStayConscious)
 			c.afflictions[i].strength = HF.BoolToNum(isUnconscious, 2)

--- a/Neurotrauma/Lua/Scripts/Server/humanupdate.lua
+++ b/Neurotrauma/Lua/Scripts/Server/humanupdate.lua
@@ -117,6 +117,25 @@ local limbtypes = {
 
 -- define all the afflictions and their update functions
 NT.Afflictions = {
+	-- Unconsciousness
+	sym_unconsciousness = {
+	update = function(c, i)
+		local isUnconscious = not NTC.GetSymptomFalse(c.character, i)
+			and (
+				NTC.GetSymptom(c.character, i)
+				or c.stats.stasis
+				or c.afflictions.brainremoved.strength > 0
+				or c.afflictions.cerebralhypoxia.strength > 100
+				or c.afflictions.coma.strength > 15
+				or c.afflictions.t_arterialcut.strength > 0
+				or c.afflictions.seizure.strength > 0.1
+				or c.afflictions.opiateoverdose.strength > 60
+				or c.character.Vitality <= 0
+			)
+			and not c.character.HasAbilityFlag(AbilityFlags.AlwaysStayConscious)
+		c.afflictions[i].strength = HF.BoolToNum(isUnconscious, 2)
+	end,
+	},
 	-- Arterial cuts
 	t_arterialcut = {},
 	-- Fractures and amputations
@@ -946,24 +965,6 @@ NT.Afflictions = {
 
 	-- /// Symptoms ///
 	--==============================================================================
-	sym_unconsciousness = {
-		update = function(c, i)
-			local isUnconscious = not NTC.GetSymptomFalse(c.character, i)
-				and (
-					NTC.GetSymptom(c.character, i)
-					or c.stats.stasis
-					or c.afflictions.brainremoved.strength > 0
-					or c.afflictions.cerebralhypoxia.strength > 100
-					or c.afflictions.coma.strength > 15
-					or c.afflictions.t_arterialcut.strength > 0
-					or c.afflictions.seizure.strength > 0.1
-					or c.afflictions.opiateoverdose.strength > 60
-					or c.character.Vitality <= 0
-				)
-				and not c.character.HasAbilityFlag(AbilityFlags.AlwaysStayConscious)
-			c.afflictions[i].strength = HF.BoolToNum(isUnconscious, 2)
-		end,
-	},
 	tachycardia = {
 		update = function(c, i)
 			-- harmless symptom (doesnt lead to fibrillation)

--- a/Neurotrauma/Xml/Afflictions.xml
+++ b/Neurotrauma/Xml/Afflictions.xml
@@ -5308,23 +5308,6 @@ thats what the vomiting symptom is for -->
   <!-- Vanilla affliction override end -->
   <!-- Vanilla affliction override start -->
     <Affliction
-      identifier="implacable"
-      type="talentbuff"
-      isbuff="true"
-      limbspecific="false"
-      maxstrength="15"
-      treatmentthreshold="1000"
-      iconcolors="33,75,78;126,211,224;126,211,224;227,247,249">
-      <Effect minstrength="0" maxstrength="15"
-        strengthchange="-0.25">
-        <StatValue stattype="AttackMultiplier" value="0.25" />
-        <AbilityFlag flagtype="AlwaysStayConscious" />
-      </Effect>
-      <Icon texture="Content/UI/TalentsIcons3.png" sheetindex="0,0" sheetelementsize="128,128" color="10,193,114,255" origin="0,0"/>
-    </Affliction>
-  <!-- Vanilla affliction override end -->
-  <!-- Vanilla affliction override start -->
-    <Affliction
     identifier="combatstimulant"
     type="talentbuff"
     isbuff="true"

--- a/Neurotrauma/Xml/Talents.xml
+++ b/Neurotrauma/Xml/Talents.xml
@@ -69,7 +69,7 @@
                                 <Affliction identifier="implacable" amount="15.0"/>
                             </StatusEffect>
                             <StatusEffect type="OnAbility" target="Character" multiplyafflictionsbymaxvitality="true" disabledeltatime="true" delay="2.1">
-                                <ReduceAffliction identifier="stun" amount="15.0"/>
+                                <ReduceAffliction identifier="stun" amount="5.0"/>
                             </StatusEffect>
                         </StatusEffects>
                     </CharacterAbilityApplyStatusEffects>

--- a/Neurotrauma/Xml/Talents.xml
+++ b/Neurotrauma/Xml/Talents.xml
@@ -68,6 +68,9 @@
                             <StatusEffect type="OnAbility" target="Character" multiplyafflictionsbymaxvitality="true" disabledeltatime="true" >
                                 <Affliction identifier="implacable" amount="15.0"/>
                             </StatusEffect>
+                            <StatusEffect type="OnAbility" target="Character" multiplyafflictionsbymaxvitality="true" disabledeltatime="true" delay="2.1">
+                                <ReduceAffliction identifier="stun" amount="15.0"/>
+                            </StatusEffect>
                         </StatusEffects>
                     </CharacterAbilityApplyStatusEffects>
                 </Abilities>

--- a/Neurotrauma/Xml/Talents.xml
+++ b/Neurotrauma/Xml/Talents.xml
@@ -50,5 +50,28 @@
                 </Abilities>
             </AbilityGroupEffect>
         </Talent>
+
+        <Talent identifier="implacable">
+            <Description tag="talentdescription.cannotfallunconsciousforseconds">
+                <Replace tag="[powerincrease]" value="25" color="gui.green"/>
+                <Replace tag="[seconds]" value="15" color="gui.green"/>
+            </Description>
+            <Description tag="talentdescription.maxtriggeruntildeath"/>
+            <Icon texture="Content/UI/TalentsIcons1.png" sheetindex="2,3" sheetelementsize="128,128"/>
+            <AbilityGroupInterval maxtriggercount="1" >
+                <Conditions>
+                    <AbilityConditionHasAffliction afflictionidentifier="sym_unconsciousness"/>
+                </Conditions>
+                <Abilities>
+                    <CharacterAbilityApplyStatusEffects>
+                        <StatusEffects>
+                            <StatusEffect type="OnAbility" target="Character" multiplyafflictionsbymaxvitality="true" disabledeltatime="true" >
+                                <Affliction identifier="implacable" amount="15.0"/>
+                            </StatusEffect>
+                        </StatusEffects>
+                    </CharacterAbilityApplyStatusEffects>
+                </Abilities>
+            </AbilityGroupInterval>
+        </Talent>
     </Override>
 </Talents>


### PR DESCRIPTION
Changes:
- Can no longer have sym_unconsciousness when character has AlwaysStayConscious ability flag
- no longer overriding Implacable affliction
- new override for Implacable talent
- moved sym_unconsciousness to the top of humanupdate so it runs before the stun check

This will allow greater compatibility with mods that use AlwaysStayConscious to, well, keep the character conscious. I assume this is more of an oversight than intended design.

The Implacable affliction buff was removed as it is no longer needed; this change will make it so the character is always conscious as long as they have Implacable, regardless of whether they have other conditions such as hypoxemia. A utility override was added to the Implacable talent so it procs when the character gains unconsciousness, as opposed to only being under 0 vitality.

There is one issue I haven't found a fix for yet, which is that going unconscious procs the stun before implacable kicks in, causing the user to be stunned for several seconds when implacable is supposed to proc.