### PR TITLE
Add improved addon compatibility with the Drainage Bag.

### DIFF
--- a/Neurotrauma/Lua/Scripts/Server/items.lua
+++ b/Neurotrauma/Lua/Scripts/Server/items.lua
@@ -1973,6 +1973,12 @@ NT.ItemMethods.spinalimplant = function(item, usingCharacter, targetCharacter, l
 	end
 end
 
+-- This makes it so we don't have to override the item to add a new affliction.
+NT.DrainageAfflictions = {
+	"pneumothorax",
+	"needlec",
+}
+
 NT.ItemMethods.drainage = function(item, usingCharacter, targetCharacter, limb)
 	local limbtype = limb.type
 
@@ -1986,8 +1992,9 @@ NT.ItemMethods.drainage = function(item, usingCharacter, targetCharacter, limb)
 		and HF.HasAfflictionLimb(targetCharacter, "retractedskin", limbtype)
 		and HF.HasAffliction(targetCharacter, "pneumothorax")
 	then
-		HF.SetAffliction(targetCharacter, "pneumothorax", 0, usingCharacter)
-		HF.SetAffliction(targetCharacter, "needlec", 0, usingCharacter)
+		for index, affliction in pairs(NT.DrainageAfflictions) do -- We cycle through all the afflictions.
+			HF.SetAffliction(targetCharacter, affliction, 0, usingCharacter)
+		end
 
 		if HF.Chance(NTC.GetMultiplier(usingCharacter, "drainageconsumechance")) then
 			HF.RemoveItem(item)

--- a/Neurotrauma/Lua/Scripts/Server/items.lua
+++ b/Neurotrauma/Lua/Scripts/Server/items.lua
@@ -1974,13 +1974,22 @@ NT.ItemMethods.spinalimplant = function(item, usingCharacter, targetCharacter, l
 end
 
 -- This makes it so we don't have to override the item to add a new affliction.
+-- needlec doesn't go in here, since in prior versions it alone, wouldn't allow drainage.
 NT.DrainageAfflictions = {
-	"pneumothorax",
-	"needlec",
+	"pneumothorax"
 }
 
 NT.ItemMethods.drainage = function(item, usingCharacter, targetCharacter, limb)
 	local limbtype = limb.type
+
+	local canUse = function () -- This is why we keep needlec out, so we can check the afflictions.
+		for index, affliction in pairs(NT.DrainageAfflictions) do -- We cycle through all the afflictions.
+			if HF.HasAffliction(targetCharacter, affliction) then
+				return true
+			end
+		end
+		return false
+	end
 
 	-- don't work on stasis
 	if HF.HasAffliction(targetCharacter, "stasis", 0.1) then
@@ -1990,11 +1999,12 @@ NT.ItemMethods.drainage = function(item, usingCharacter, targetCharacter, limb)
 	if
 		limbtype == LimbType.Torso
 		and HF.HasAfflictionLimb(targetCharacter, "retractedskin", limbtype)
-		and HF.HasAffliction(targetCharacter, "pneumothorax")
+		and canUse()
 	then
 		for index, affliction in pairs(NT.DrainageAfflictions) do -- We cycle through all the afflictions.
 			HF.SetAffliction(targetCharacter, affliction, 0, usingCharacter)
 		end
+		HF.SetAffliction(targetCharacter, "needlec", 0, usingCharacter) -- This is seperate, since it shouldnt allow a drainage.
 
 		if HF.Chance(NTC.GetMultiplier(usingCharacter, "drainageconsumechance")) then
 			HF.RemoveItem(item)
@@ -2007,6 +2017,7 @@ NT.ItemMethods.drainage = function(item, usingCharacter, targetCharacter, limb)
 		end
 	end
 end
+
 NT.ItemMethods.needle = function(item, usingCharacter, targetCharacter, limb)
 	local limbtype = limb.type
 	-- don't work on stasis

--- a/Neurotrauma/Lua/Scripts/Server/ntcompat.lua
+++ b/Neurotrauma/Lua/Scripts/Server/ntcompat.lua
@@ -174,7 +174,6 @@ function NTC.AddSuturedAffliction(identifier, surgeryskillgain, requiredafflicti
 	end, 1)
 end
 
--- NT.DrainageAfflictions
 -- use this function to register an affliction to be healed by drainage
 -- identifier: the identifier of the affliction to be healed
 function NTC.AddDrainageAffliction(identifier)

--- a/Neurotrauma/Lua/Scripts/Server/ntcompat.lua
+++ b/Neurotrauma/Lua/Scripts/Server/ntcompat.lua
@@ -174,6 +174,17 @@ function NTC.AddSuturedAffliction(identifier, surgeryskillgain, requiredafflicti
 	end, 1)
 end
 
+-- NT.DrainageAfflictions
+-- use this function to register an affliction to be healed by drainage
+-- identifier: the identifier of the affliction to be healed
+function NTC.AddDrainageAffliction(identifier)
+	Timer.Wait(function()
+		if not HF.TableContains(NT.DrainageAfflictions, identifier) then
+			table.insert(NT.DrainageAfflictions,identifier)
+		end
+	end, 1)
+end
+
 NTC.AfflictionsAffectingVitality = {
 	bleeding = true,
 	bleedingnonstop = true,


### PR DESCRIPTION
I've noted that NT has many useful compat features, like with sutures. However some items lack this same compat, so I added the ability to add new afflictions to the drainage bag without overriding. This lets me simply add an affliction from my addon without overriding the entire drainage bag. It works identically from my testing.

Also, I know this is a bit niche, but I thought it's a commonly used item, so it wouldn't hurt.