### PR TITLE
Stun bot crewmembers when they have a surgery incision

### DIFF
--- a/Neurotrauma/Xml/Afflictions.xml
+++ b/Neurotrauma/Xml/Afflictions.xml
@@ -3746,6 +3746,12 @@ thats what the vomiting symptom is for -->
         <Conditional analgesia="lte 0.5" anesthesia="lte 0.5" sym_unconsciousness="lte 0.1"/>
         <Affliction identifier="traumaticshock" amount="2"/>
       </StatusEffect>
+      <StatusEffect target="Character" multiplyafflictionsbymaxvitality="true" interval="0.5" disabledeltatime="true" comparison="and">
+        <Conditional isonplayerteam="true"/>
+        <Conditional isbot="true"/>
+        <Conditional stun="lt 0.5"/>
+        <Affliction identifier="stun" amount="1"/>
+      </StatusEffect>
     </Effect>
     <icon texture="%ModDir%/Images/AfflictionIcons.png" sheetindex="0,7" sheetelementsize="128,128" origin="0,0"/>
   </Affliction>


### PR DESCRIPTION
Bots get a short stun as long as they have a surgery incision. Makes them easier to drag to a table or onto a table. So, you could give a bot incision + clamped bleeders, then drag them onto a surgery table with a dialysis filter, which is more convenient than stunning and handcuffing them.