### PR TITLE
Possible Config UI updates

### DIFF
--- a/Neurotrauma/Lua/Scripts/Client/configgui.lua
+++ b/Neurotrauma/Lua/Scripts/Client/configgui.lua
@@ -23,12 +23,12 @@ end
 -- Function that autofills the addon dropdown
 -- We also automatically make the UI display the names as "NT [mod]" to match their Content Package / Steam Workhop name to minimise confusion.
 local function PopulateDropdown(dropdown)
-    ExpansionNameForUI = {}
+	ExpansionNameForUI = {}
 
-    for _, expansion in ipairs(NTConfig.Expansions) do
-        local name = tostring(expansion.Name)
+	for _, expansion in ipairs(NTConfig.Expansions) do
+		local name = tostring(expansion.Name)
 		-- First, we make the UI Name the same as their expansion name
-        local uiName = name
+		local uiName = name
 		-- Excluding Neurotrauma itself, add NT at the front if it does not already have that
 		if expansion.Name ~= "Neurotrauma" then
 			if not string.find(uiName, "^NT%s") then
@@ -36,17 +36,16 @@ local function PopulateDropdown(dropdown)
 			end
 		end
 		-- Add them to a lookup table for later
-        table.insert(ExpansionNameForUI, {uiName, name})
+		table.insert(ExpansionNameForUI, { uiName, name })
 		-- Finally, add it to the dropdown menu
-        dropdown.AddItem(uiName)
-    end
+		dropdown.AddItem(uiName)
+	end
 end
 
 -- TODO: Readd the difficulty calculation I kinda dont care about it right now so it can fuck off
 
 -- Function to determine how the layout should be structured
 local function PrebuildConfigLayout(entries, selectedExpansion)
-
 	-- This table will contain subtables that determine how the ConstructUI function actually 'constructs' the UI.
 	-- These chunks can be gone over using Ipairs to ensure the order is correct (a previous test made unrelated settings render together)
 	local LayoutChunks = {}
@@ -54,7 +53,6 @@ local function PrebuildConfigLayout(entries, selectedExpansion)
 	local lastType = nil
 
 	for key, entry in pairs(entries) do
-
 		-- Grab actual expansion name based on their UIName
 		for _, entry in ipairs(ExpansionNameForUI) do
 			if entry[1] == selectedExpansion then
@@ -69,7 +67,7 @@ local function PrebuildConfigLayout(entries, selectedExpansion)
 
 		-- Automatically add some white space between unique item types to prevent bleeding
 		if entry.type ~= lastType and lastType ~= nil then
-			table.insert(LayoutChunks, {type = "spacer"})
+			table.insert(LayoutChunks, { type = "spacer" })
 		end
 
 		lastType = entry.type
@@ -78,35 +76,31 @@ local function PrebuildConfigLayout(entries, selectedExpansion)
 		-- Interrupt a group if it exists
 		if entry.type == "category" then
 			CurrentGroup = nil
-			table.insert(LayoutChunks, {type = "category", entry = entry})
+			table.insert(LayoutChunks, { type = "category", entry = entry })
 
 		-- Floats / Strings until now were just using up way too much screen space. We want to put these into a LayoutGroup together to maximise screen usage.
 		-- If entries have 'group=true', then all entries of the same type that follow one another will be grouped together. If there are other entry types (like categories) in-between, they will not.
 		-- This prevents unrelated settings from merging together + adds reverse-compat
 		elseif entry.type == "float" and entry.group then
-			
 			-- Make a group and keep adding config entries that come after this as long as the criteria stands
 			if not CurrentGroup or CurrentGroup.type ~= "float_group" then
-				CurrentGroup = {type = "float_group", items = {}}
+				CurrentGroup = { type = "float_group", items = {} }
 				table.insert(LayoutChunks, CurrentGroup)
 			end
 
-			table.insert(CurrentGroup.items, {key = key, entry = entry})
-
+			table.insert(CurrentGroup.items, { key = key, entry = entry })
 		elseif entry.type == "string" and entry.group then
-			
 			if not CurrentGroup or CurrentGroup.type ~= "string_group" then
-				CurrentGroup = {type = "string_group", items = {}}
+				CurrentGroup = { type = "string_group", items = {} }
 				table.insert(LayoutChunks, CurrentGroup)
 			end
 
-			table.insert(CurrentGroup.items, {key = key, entry = entry})
-
+			table.insert(CurrentGroup.items, { key = key, entry = entry })
 
 		-- Anything else is anything that shouldn't be grouped. Interrupt a group if it exists and add the setting as standalone.
 		else
 			CurrentGroup = nil
-			table.insert(LayoutChunks, {type = "standalone", key = key, entry = entry})
+			table.insert(LayoutChunks, { type = "standalone", key = key, entry = entry })
 		end
 
 		::continue::
@@ -116,7 +110,6 @@ local function PrebuildConfigLayout(entries, selectedExpansion)
 end
 
 local function PopulateSettingsIntoUI(list, selectedExpansion)
-
 	list.Content:ClearChildren()
 
 	-- Infotext (should always be shown)
@@ -137,7 +130,6 @@ local function PopulateSettingsIntoUI(list, selectedExpansion)
 	local LayoutChunks = PrebuildConfigLayout(NTConfig.Entries, selectedExpansion)
 	-- Go over the pre-generated Layout table and construct settings procedurally
 	for _, chunk in ipairs(LayoutChunks) do
-
 		-- Categories
 		if chunk.type == "category" then
 			local tb_ProceduralCategoryHeader = GUI.TextBlock(
@@ -160,7 +152,6 @@ local function PopulateSettingsIntoUI(list, selectedExpansion)
 
 			-- Ungrouped float
 			if entry.type == "float" then
-
 				local minrange = (entry.range and entry.range[1]) or ""
 				local maxrange = (entry.range and entry.range[2]) or ""
 
@@ -183,7 +174,8 @@ local function PopulateSettingsIntoUI(list, selectedExpansion)
 					tb_EntryInformation.ToolTip = entry.description
 				end
 
-				local scalar = GUI.NumberInput(GUI.RectTransform(Vector2(1, 0.08), list.Content.RectTransform), NumberType.Float)
+				local scalar =
+					GUI.NumberInput(GUI.RectTransform(Vector2(1, 0.08), list.Content.RectTransform), NumberType.Float)
 
 				scalar.valueStep = 0.1
 				scalar.MinValueFloat = entry.range and entry.range[1] or 0
@@ -196,7 +188,6 @@ local function PopulateSettingsIntoUI(list, selectedExpansion)
 
 			-- Bool
 			elseif entry.type == "bool" then
-
 				local rect = GUI.RectTransform(Vector2(0.5, 1), list.Content.RectTransform)
 				local toggle = GUI.TickBox(rect, entry.name)
 
@@ -212,7 +203,6 @@ local function PopulateSettingsIntoUI(list, selectedExpansion)
 
 			-- String (a textblock to input)
 			elseif entry.type == "string" then
-
 				local style = ""
 				if entry.style ~= nil then
 					style = " (" .. entry.style .. ")"
@@ -244,7 +234,14 @@ local function PopulateSettingsIntoUI(list, selectedExpansion)
 
 				-- Make MultiLineTextBox the default, but now allow normal ones too. A single line entry does not need a multi-line textblock.
 				if entry.noMLTB == true then
-					stringinput = GUI.TextBox(GUI.RectTransform(Vector2(1, entry.boxsize), list.Content.RectTransform), "", nil, nil, nil, true)
+					stringinput = GUI.TextBox(
+						GUI.RectTransform(Vector2(1, entry.boxsize), list.Content.RectTransform),
+						"",
+						nil,
+						nil,
+						nil,
+						true
+					)
 				else
 					stringinput = MultiLineTextBox(list.Content.RectTransform, "", entry.boxsize)
 				end
@@ -271,12 +268,12 @@ local function PopulateSettingsIntoUI(list, selectedExpansion)
 				if not row or (count % MaxPerRow == 0) then
 					row = GUI.LayoutGroup(GUI.RectTransform(Vector2(1, 0.09), list.Content.RectTransform), true)
 				end
-				
+
 				-- Safety check!
-				if not row then 
-					return 
+				if not row then
+					return
 				end
-				
+
 				-- This determines how the space in the UI is used, tied together to make fucking around a bit easier
 				row.RelativeSpacing = 0.01
 
@@ -286,9 +283,9 @@ local function PopulateSettingsIntoUI(list, selectedExpansion)
 
 				local baseWidth = 1 / MaxPerRow
 
-				local textcellwidth   = baseWidth * Text_space
+				local textcellwidth = baseWidth * Text_space
 				local scalarcellwidth = baseWidth * Scalar_space
-				local resetcellwidth  = baseWidth * Reset_space
+				local resetcellwidth = baseWidth * Reset_space
 
 				local key = item.key
 				local entry = item.entry
@@ -298,11 +295,14 @@ local function PopulateSettingsIntoUI(list, selectedExpansion)
 				-- Part of the group that holds text
 				local textcell = GUI.LayoutGroup(GUI.RectTransform(Vector2(textcellwidth, 1), row.RectTransform), false)
 				-- Part of the group that holds the numberinput box
-				local scalarcell = GUI.LayoutGroup(GUI.RectTransform(Vector2(scalarcellwidth, 1), row.RectTransform), false)
+				local scalarcell =
+					GUI.LayoutGroup(GUI.RectTransform(Vector2(scalarcellwidth, 1), row.RectTransform), false)
 				-- In case a reset button is set
-				local resetbuttoncell = GUI.LayoutGroup(GUI.RectTransform(Vector2(resetcellwidth, 0.59), row.RectTransform), false)
+				local resetbuttoncell =
+					GUI.LayoutGroup(GUI.RectTransform(Vector2(resetcellwidth, 0.59), row.RectTransform), false)
 				-- Relativespacing but larger space for the center instead of everywhere
-				local additionalspacecell = GUI.LayoutGroup(GUI.RectTransform(Vector2(resetcellwidth, 0.59), row.RectTransform), false)
+				local additionalspacecell =
+					GUI.LayoutGroup(GUI.RectTransform(Vector2(resetcellwidth, 0.59), row.RectTransform), false)
 
 				local minrange = entry.range and entry.range[1] or ""
 				local maxrange = entry.range and entry.range[2] or ""
@@ -320,7 +320,8 @@ local function PopulateSettingsIntoUI(list, selectedExpansion)
 
 				tb_EntryInformation.CanBeFocused = false
 
-				local scalar = GUI.NumberInput(GUI.RectTransform(Vector2(1, 0.6), scalarcell.RectTransform), NumberType.Float)
+				local scalar =
+					GUI.NumberInput(GUI.RectTransform(Vector2(1, 0.6), scalarcell.RectTransform), NumberType.Float)
 				scalar.PlusButton.RectTransform.RelativeSize = Vector2(1, 0.5)
 				scalar.MinusButton.RectTransform.RelativeSize = Vector2(1, 0.5)
 
@@ -334,12 +335,18 @@ local function PopulateSettingsIntoUI(list, selectedExpansion)
 				end
 
 				-- Leftover space in the Row goes to the reset button if enabled
-				if entry.resettable then 
-					resetButton = GUI.Button(GUI.RectTransform(Vector2(1, 1), resetbuttoncell.RectTransform, GUI.Anchor.BottomLeft), GUI.Alignment.BottomLeft, nil, Transparent)
+				if entry.resettable then
+					resetButton = GUI.Button(
+						GUI.RectTransform(Vector2(1, 1), resetbuttoncell.RectTransform, GUI.Anchor.BottomLeft),
+						GUI.Alignment.BottomLeft,
+						nil,
+						Transparent
+					)
 					-- Give the reset button a sprite that matches its function (yoinked from basegame)
-					local resetButtonStyle = GUI.Image(GUI.RectTransform(Vector2(1, 1), resetButton.RectTransform), "GUIButtonRefresh")
+					local resetButtonStyle =
+						GUI.Image(GUI.RectTransform(Vector2(1, 1), resetButton.RectTransform), "GUIButtonRefresh")
 					resetButtonStyle.ToolTip = "Reset to default"
-					
+
 					-- On button press, fetch default value.
 					resetButton.OnClicked = function()
 						local defaultValue = entry.default
@@ -364,37 +371,39 @@ local function PopulateSettingsIntoUI(list, selectedExpansion)
 				end
 
 				-- Safety check!
-				if not row then 
-					return 
+				if not row then
+					return
 				end
-				
+
 				row.RelativeSpacing = 0.01
 
 				local Text_space = 0.50
 				-- Any less than 0.33 per string and the max value (255,255,255) or 3 digits per value will bleed (at 1920 * 1080 default)
 				local String_space = 0.33
-				local Reset_space = 0.07 
+				local Reset_space = 0.07
 
 				local baseWidth = 1 / MaxPerRow
 
-				local textcellwidth   = baseWidth * Text_space
+				local textcellwidth = baseWidth * Text_space
 				local scalarcellwidth = baseWidth * String_space
-				local resetcellwidth  = baseWidth * Reset_space
+				local resetcellwidth = baseWidth * Reset_space
 
 				local key = item.key
 				local entry = item.entry
 				local resetButton
 
-
 				-- Make each subdivided part of the group their own
 				-- Part of the group that holds text
 				local textcell = GUI.LayoutGroup(GUI.RectTransform(Vector2(textcellwidth, 1), row.RectTransform), false)
 				-- Part of the group that holds the input box
-				local stringinputcell = GUI.LayoutGroup(GUI.RectTransform(Vector2(scalarcellwidth, 1), row.RectTransform), false)
+				local stringinputcell =
+					GUI.LayoutGroup(GUI.RectTransform(Vector2(scalarcellwidth, 1), row.RectTransform), false)
 				-- In case a reset button is set
-				local resetbuttoncell = GUI.LayoutGroup(GUI.RectTransform(Vector2(resetcellwidth, 0.45), row.RectTransform), false)
+				local resetbuttoncell =
+					GUI.LayoutGroup(GUI.RectTransform(Vector2(resetcellwidth, 0.45), row.RectTransform), false)
 				-- Relativespacing but larger space for the center instead of everywhere
-				local additionalspacecell = GUI.LayoutGroup(GUI.RectTransform(Vector2(resetcellwidth, 0.59), row.RectTransform), false)
+				local additionalspacecell =
+					GUI.LayoutGroup(GUI.RectTransform(Vector2(resetcellwidth, 0.59), row.RectTransform), false)
 
 				local style = ""
 				if entry.style ~= nil then
@@ -424,9 +433,20 @@ local function PopulateSettingsIntoUI(list, selectedExpansion)
 				-- Not all strings need a MultiLineTextBox, especially since they can just yoink the mouse cursor while scrolling.
 				-- Make MLTB's a toggleable option
 				if entry.noMLTB == true then
-					stringinput = GUI.TextBox(GUI.RectTransform(Vector2(1, entry.boxsize), stringinputcell.RectTransform, GUI.Anchor.CenterLeft), "", nil, nil, nil, true)
+					stringinput = GUI.TextBox(
+						GUI.RectTransform(
+							Vector2(1, entry.boxsize),
+							stringinputcell.RectTransform,
+							GUI.Anchor.CenterLeft
+						),
+						"",
+						nil,
+						nil,
+						nil,
+						true
+					)
 				else
-					stringinput = MultiLineTextBox(stringinputcell.RectTransform, "", (entry.boxsize))
+					stringinput = MultiLineTextBox(stringinputcell.RectTransform, "", entry.boxsize)
 				end
 
 				stringinput.Text = table.concat(entry.value, ",")
@@ -436,12 +456,18 @@ local function PopulateSettingsIntoUI(list, selectedExpansion)
 				end
 
 				-- Leftover space in the Row goes to the reset button if enabled
-				if entry.resettable then 
-					resetButton = GUI.Button(GUI.RectTransform(Vector2(1, 1), resetbuttoncell.RectTransform), GUI.Alignment.CenterRight, nil, Transparent)
+				if entry.resettable then
+					resetButton = GUI.Button(
+						GUI.RectTransform(Vector2(1, 1), resetbuttoncell.RectTransform),
+						GUI.Alignment.CenterRight,
+						nil,
+						Transparent
+					)
 					-- Give the reset button a sprite that matches its function (yoinked from basegame)
-					local resetButtonStyle = GUI.Image(GUI.RectTransform(Vector2(1, 1), resetButton.RectTransform), "GUIButtonRefresh")
+					local resetButtonStyle =
+						GUI.Image(GUI.RectTransform(Vector2(1, 1), resetButton.RectTransform), "GUIButtonRefresh")
 					resetButtonStyle.ToolTip = "Reset to default"
-					
+
 					-- On button press, fetch default value.
 					resetButton.OnClicked = function()
 						entry.value = entry.default
@@ -479,7 +505,15 @@ local function ConstructUI(parent)
 
 	-- Don't show the dropdown if we only have Neurotrauma or no other addons that have settings to show
 	if dropdownheight > 1 then
-		local dropdown_AddonSelection = GUI.DropDown(GUI.RectTransform(Vector2(0.18, 1), title.RectTransform), "", dropdownheight - 2, nil, false, false, GUI.Alignment.CenterLeft)
+		local dropdown_AddonSelection = GUI.DropDown(
+			GUI.RectTransform(Vector2(0.18, 1), title.RectTransform),
+			"",
+			dropdownheight - 2,
+			nil,
+			false,
+			false,
+			GUI.Alignment.CenterLeft
+		)
 		dropdown_AddonSelection.ListBox.RectTransform.RelativeOffset = (Vector2(0, 0.5))
 		PopulateDropdown(dropdown_AddonSelection)
 		dropdown_AddonSelection.Select(0)
@@ -494,7 +528,7 @@ local function ConstructUI(parent)
 				return
 			end
 
-			selectedExpansion  = newSelection
+			selectedExpansion = newSelection
 
 			-- Redo content based on new selection
 			PopulateSettingsIntoUI(list, selectedExpansion)
@@ -508,14 +542,18 @@ end
 Networking.Receive("NT.ConfigUpdate", function(msg)
 	NTConfig.ReceiveConfig(msg)
 
-    if configUI == nil then return end
-    if configUI.RectTransform == nil then return end
+	if configUI == nil then
+		return
+	end
+	if configUI.RectTransform == nil then
+		return
+	end
 
-    local parent = configUI.RectTransform.Parent
+	local parent = configUI.RectTransform.Parent
 
-    configUI = nil
+	configUI = nil
 
-    configUI = ConstructUI(parent)
+	configUI = ConstructUI(parent)
 end)
 
 easySettings.AddMenu("Neurotrauma", function(parent)

--- a/Neurotrauma/Lua/Scripts/Client/configgui.lua
+++ b/Neurotrauma/Lua/Scripts/Client/configgui.lua
@@ -4,6 +4,12 @@ local MultiLineTextBox = dofile(NT.Path .. "/Lua/Scripts/Client/MultiLineTextBox
 local GUIComponent = LuaUserData.CreateStatic("Barotrauma.GUIComponent")
 local configUI
 
+-- Did you know the default background colour is not true black?
+local Transparent = Color(2, 2, 2)
+-- Barotrauma beige
+local DefaultTextColour = Color(210, 200, 154)
+local ExpansionNameForUI = {}
+
 local function CommaStringToTable(str)
 	local tbl = {}
 
@@ -14,190 +20,437 @@ local function CommaStringToTable(str)
 	return tbl
 end
 
---calculate difficulty
-local function DetermineDifficulty()
-	local difficulty = 0
-	local defaultDifficulty = 0
-	local res = ""
+-- Function that autofills the addon dropdown
+-- We also automatically make the UI display the names as "NT [mod]" to match their Content Package / Steam Workhop name to minimise confusion.
+local function PopulateDropdown(dropdown)
+    ExpansionNameForUI = {}
 
-	for key, entry in pairs(NTConfig.Entries) do
-		if entry.difficultyCharacteristics then
-			local entryValue = entry.value
-			local entryValueDefault = entry.default
-			local diffMultiplier = 1
-			if entry.type == "bool" then
-				entryValue = HF.BoolToNum(entry.value)
-				entryValueDefault = HF.BoolToNum(entry.default)
+    for _, expansion in ipairs(NTConfig.Expansions) do
+        local name = tostring(expansion.Name)
+		-- First, we make the UI Name the same as their expansion name
+        local uiName = name
+		-- Excluding Neurotrauma itself, add NT at the front if it does not already have that
+		if expansion.Name ~= "Neurotrauma" then
+			if not string.find(uiName, "^NT%s") then
+				uiName = "NT " .. uiName
 			end
-			if entry.difficultyCharacteristics.multiplier then
-				diffMultiplier = entry.difficultyCharacteristics.multiplier
-			end
-
-			defaultDifficulty = defaultDifficulty + entryValueDefault * diffMultiplier
-			difficulty = difficulty + math.min(entryValue * diffMultiplier, entry.difficultyCharacteristics.max or 1)
 		end
-	end
-
-	-- normalize to 10
-	difficulty = difficulty / defaultDifficulty * 10
-
-	if difficulty > 23 then
-		res = "Impossible"
-	elseif difficulty > 16 then
-		res = "Very hard"
-	elseif difficulty > 11 then
-		res = "Hard"
-	elseif difficulty > 8 then
-		res = "Normal"
-	elseif difficulty > 6 then
-		res = "Easy"
-	elseif difficulty > 4 then
-		res = "Very easy"
-	elseif difficulty > 2 then
-		res = "Barely different"
-	else
-		res = "Vanilla but sutures"
-	end
-
-	res = res .. " (" .. HF.Round(difficulty, 1) .. ")"
-	return res
+		-- Add them to a lookup table for later
+        table.insert(ExpansionNameForUI, {uiName, name})
+		-- Finally, add it to the dropdown menu
+        dropdown.AddItem(uiName)
+    end
 end
 
---bulk of the GUI code
-local function ConstructUI(parent)
-	local list = easySettings.BasicList(parent)
+-- TODO: Readd the difficulty calculation I kinda dont care about it right now so it can fuck off
 
-	--info text
-	local userBlock = GUI.TextBlock(
+-- Function to determine how the layout should be structured
+local function PrebuildConfigLayout(entries, selectedExpansion)
+
+	-- This table will contain subtables that determine how the ConstructUI function actually 'constructs' the UI.
+	-- These chunks can be gone over using Ipairs to ensure the order is correct (a previous test made unrelated settings render together)
+	local LayoutChunks = {}
+	local CurrentGroup = nil
+	local lastType = nil
+
+	for key, entry in pairs(entries) do
+
+		-- Grab actual expansion name based on their UIName
+		for _, entry in ipairs(ExpansionNameForUI) do
+			if entry[1] == selectedExpansion then
+				selectedExpansion = entry[2]
+			end
+		end
+
+		-- Only determine layout for entries from the expansion we've selected
+		if entry.expansion ~= selectedExpansion then
+			goto continue
+		end
+
+		-- Automatically add some white space between unique item types to prevent bleeding
+		if entry.type ~= lastType and lastType ~= nil then
+			table.insert(LayoutChunks, {type = "spacer"})
+		end
+
+		lastType = entry.type
+
+		-- Categories are always standalone and should be put above the settings they govern
+		-- Interrupt a group if it exists
+		if entry.type == "category" then
+			CurrentGroup = nil
+			table.insert(LayoutChunks, {type = "category", entry = entry})
+
+		-- Floats / Strings until now were just using up way too much screen space. We want to put these into a LayoutGroup together to maximise screen usage.
+		-- If entries have 'group=true', then all entries of the same type that follow one another will be grouped together. If there are other entry types (like categories) in-between, they will not.
+		-- This prevents unrelated settings from merging together + adds reverse-compat
+		elseif entry.type == "float" and entry.group then
+			
+			-- Make a group and keep adding config entries that come after this as long as the criteria stands
+			if not CurrentGroup or CurrentGroup.type ~= "float_group" then
+				CurrentGroup = {type = "float_group", items = {}}
+				table.insert(LayoutChunks, CurrentGroup)
+			end
+
+			table.insert(CurrentGroup.items, {key = key, entry = entry})
+
+		elseif entry.type == "string" and entry.group then
+			
+			if not CurrentGroup or CurrentGroup.type ~= "string_group" then
+				CurrentGroup = {type = "string_group", items = {}}
+				table.insert(LayoutChunks, CurrentGroup)
+			end
+
+			table.insert(CurrentGroup.items, {key = key, entry = entry})
+
+
+		-- Anything else is anything that shouldn't be grouped. Interrupt a group if it exists and add the setting as standalone.
+		else
+			CurrentGroup = nil
+			table.insert(LayoutChunks, {type = "standalone", key = key, entry = entry})
+		end
+
+		::continue::
+	end
+
+	return LayoutChunks
+end
+
+local function PopulateSettingsIntoUI(list, selectedExpansion)
+
+	list.Content:ClearChildren()
+
+	-- Infotext (should always be shown)
+	local tb_BasicConfigInfo = GUI.TextBlock(
 		GUI.RectTransform(Vector2(1, 0.1), list.Content.RectTransform),
 		"Server config can be changed by owner or a client with manage settings permission. If the server doesn't allow writing into the config folder, then it must be edited manually.",
-		Color(200, 255, 255),
+		DefaultTextColour,
 		nil,
 		GUI.Alignment.Center,
 		true,
 		nil,
-		Color(0, 0, 0)
-	)
-	local difficultyBlock = GUI.TextBlock(
-		GUI.RectTransform(Vector2(1, 0.05), list.Content.RectTransform),
-		"",
-		Color(200, 255, 255),
-		nil,
-		GUI.Alignment.Center,
-		true,
-		nil,
-		Color(0, 0, 0)
+		Transparent
 	)
 
-	--set difficulty text (why does this even exist in the first place)
-	local function OnChanged()
-		difficultyRate = "Calculated difficulty rating: " .. DetermineDifficulty()
-		difficultyBlock.Text = difficultyRate
-	end
-	OnChanged()
+	-- Prevent textblocks from lighting up the background when clicked / changing the cursor on hover.
+	tb_BasicConfigInfo.CanBeFocused = false
 
-	-- procedurally construct config UI
-	for key, entry in pairs(NTConfig.Entries) do
-		if entry.type == "float" then
-			-- scalar value
-			--grab range
-			local minrange = ""
-			local maxrange = ""
+	local LayoutChunks = PrebuildConfigLayout(NTConfig.Entries, selectedExpansion)
+	-- Go over the pre-generated Layout table and construct settings procedurally
+	for _, chunk in ipairs(LayoutChunks) do
+
+		-- Categories
+		if chunk.type == "category" then
+			local tb_ProceduralCategoryHeader = GUI.TextBlock(
+				GUI.RectTransform(Vector2(1, 0.09), list.Content.RectTransform),
+				chunk.entry.name,
+				DefaultTextColour,
+				GUI.GUIStyle.LargeFont,
+				GUI.Alignment.BottomCenter,
+				true,
+				nil,
+				Transparent
+			)
+
+			tb_ProceduralCategoryHeader.CanBeFocused = false
+
+		-- Standalone items
+		elseif chunk.type == "standalone" then
+			local key = chunk.key
+			local entry = chunk.entry
+
+			-- Ungrouped float
+			if entry.type == "float" then
+
+				local minrange = (entry.range and entry.range[1]) or ""
+				local maxrange = (entry.range and entry.range[2]) or ""
+
+				local rect = GUI.RectTransform(Vector2(1, 0.04), list.Content.RectTransform)
+
+				local tb_EntryInformation = GUI.TextBlock(
+					rect,
+					entry.name .. " (" .. minrange .. "-" .. maxrange .. ")",
+					DefaultTextColour,
+					nil,
+					GUI.Alignment.Center,
+					true,
+					nil,
+					Transparent
+				)
+
+				tb_EntryInformation.CanBeFocused = false
+
+				if entry.description then
+					tb_EntryInformation.ToolTip = entry.description
+				end
+
+				local scalar = GUI.NumberInput(GUI.RectTransform(Vector2(1, 0.08), list.Content.RectTransform), NumberType.Float)
+
+				scalar.valueStep = 0.1
+				scalar.MinValueFloat = entry.range and entry.range[1] or 0
+				scalar.MaxValueFloat = entry.range and entry.range[2] or 100
+				scalar.FloatValue = NTConfig.Get(key, 1)
+
+				scalar.OnValueChanged = function()
+					NTConfig.Set(key, scalar.FloatValue)
+				end
+
+			-- Bool
+			elseif entry.type == "bool" then
+
+				local rect = GUI.RectTransform(Vector2(0.5, 1), list.Content.RectTransform)
+				local toggle = GUI.TickBox(rect, entry.name)
+
+				if entry.description then
+					toggle.ToolTip = entry.description
+				end
+
+				toggle.Selected = NTConfig.Get(key, false)
+
+				toggle.OnSelected = function()
+					NTConfig.Set(key, toggle.State == GUIComponent.ComponentState.Selected)
+				end
+
+			-- String (a textblock to input)
+			elseif entry.type == "string" then
+
+				local style = ""
+				if entry.style ~= nil then
+					style = " (" .. entry.style .. ")"
+				end
+
+				local rect = GUI.RectTransform(Vector2(1, 0.05), list.Content.RectTransform)
+
+				local tb_StringInformation = GUI.TextBlock(
+					rect,
+					entry.name .. style,
+					DefaultTextColour,
+					nil,
+					GUI.Alignment.Center,
+					true,
+					nil,
+					Transparent
+				)
+
+				-- By default, don't change cursor on hovering
+				tb_StringInformation.CanBeFocused = false
+
+				-- If there's a tooltip, set it and re-enable hovering
+				if entry.description then
+					tb_StringInformation.ToolTip = entry.description
+					tb_StringInformation.CanBeFocused = true
+				end
+
+				local stringinput
+
+				-- Make MultiLineTextBox the default, but now allow normal ones too. A single line entry does not need a multi-line textblock.
+				if entry.noMLTB == true then
+					stringinput = GUI.TextBox(GUI.RectTransform(Vector2(1, entry.boxsize), list.Content.RectTransform), "", nil, nil, nil, true)
+				else
+					stringinput = MultiLineTextBox(list.Content.RectTransform, "", entry.boxsize)
+				end
+
+				stringinput.Text = table.concat(entry.value, ",")
+
+				stringinput.OnTextChangedDelegate = function(textBox)
+					entry.value = CommaStringToTable(textBox.Text)
+				end
+			end
+
+		-- Auto-added empty space
+		elseif chunk.type == "spacer" then
+			GUI.LayoutGroup(GUI.RectTransform(Vector2(1, 0.02), list.Content.RectTransform), false)
+
+		-- Grouped Floats
+		elseif chunk.type == "float_group" then
+			local MaxPerRow = 2
+			local row = nil
 			local count = 0
-			for _, rangegrab in pairs(entry.range) do
-				if count == 0 then
-					minrange = rangegrab
+
+			for _, item in ipairs(chunk.items) do
+				-- Make a new LayoutGroup to add entries into everytime the MaxPerRow is hit (default of 2)
+				if not row or (count % MaxPerRow == 0) then
+					row = GUI.LayoutGroup(GUI.RectTransform(Vector2(1, 0.09), list.Content.RectTransform), true)
 				end
-				if count == 1 then
-					maxrange = rangegrab
+				
+				-- Safety check!
+				if not row then 
+					return 
 				end
+				
+				-- This determines how the space in the UI is used, tied together to make fucking around a bit easier
+				row.RelativeSpacing = 0.01
+
+				local Text_space = 0.53
+				local Scalar_space = 0.30
+				local Reset_space = 0.07
+
+				local baseWidth = 1 / MaxPerRow
+
+				local textcellwidth   = baseWidth * Text_space
+				local scalarcellwidth = baseWidth * Scalar_space
+				local resetcellwidth  = baseWidth * Reset_space
+
+				local key = item.key
+				local entry = item.entry
+				local resetButton
+
+				-- Make each subdivided part of the group their own
+				-- Part of the group that holds text
+				local textcell = GUI.LayoutGroup(GUI.RectTransform(Vector2(textcellwidth, 1), row.RectTransform), false)
+				-- Part of the group that holds the numberinput box
+				local scalarcell = GUI.LayoutGroup(GUI.RectTransform(Vector2(scalarcellwidth, 1), row.RectTransform), false)
+				-- In case a reset button is set
+				local resetbuttoncell = GUI.LayoutGroup(GUI.RectTransform(Vector2(resetcellwidth, 0.59), row.RectTransform), false)
+				-- Relativespacing but larger space for the center instead of everywhere
+				local additionalspacecell = GUI.LayoutGroup(GUI.RectTransform(Vector2(resetcellwidth, 0.59), row.RectTransform), false)
+
+				local minrange = entry.range and entry.range[1] or ""
+				local maxrange = entry.range and entry.range[2] or ""
+
+				local tb_EntryInformation = GUI.TextBlock(
+					GUI.RectTransform(Vector2(1, 0.7), textcell.RectTransform),
+					entry.name .. " (" .. minrange .. "-" .. maxrange .. ")",
+					DefaultTextColour,
+					nil,
+					GUI.Alignment.Center,
+					true,
+					nil,
+					Transparent
+				)
+
+				tb_EntryInformation.CanBeFocused = false
+
+				local scalar = GUI.NumberInput(GUI.RectTransform(Vector2(1, 0.6), scalarcell.RectTransform), NumberType.Float)
+				scalar.PlusButton.RectTransform.RelativeSize = Vector2(1, 0.5)
+				scalar.MinusButton.RectTransform.RelativeSize = Vector2(1, 0.5)
+
+				scalar.valueStep = 0.1
+				scalar.MinValueFloat = entry.range and entry.range[1] or 0
+				scalar.MaxValueFloat = entry.range and entry.range[2] or 100
+				scalar.FloatValue = NTConfig.Get(key, 1)
+
+				scalar.OnValueChanged = function()
+					NTConfig.Set(key, scalar.FloatValue)
+				end
+
+				-- Leftover space in the Row goes to the reset button if enabled
+				if entry.resettable then 
+					resetButton = GUI.Button(GUI.RectTransform(Vector2(1, 1), resetbuttoncell.RectTransform, GUI.Anchor.BottomLeft), GUI.Alignment.BottomLeft, nil, Transparent)
+					-- Give the reset button a sprite that matches its function (yoinked from basegame)
+					local resetButtonStyle = GUI.Image(GUI.RectTransform(Vector2(1, 1), resetButton.RectTransform), "GUIButtonRefresh")
+					resetButtonStyle.ToolTip = "Reset to default"
+					
+					-- On button press, fetch default value.
+					resetButton.OnClicked = function()
+						local defaultValue = entry.default
+						scalar.FloatValue = defaultValue
+						NTConfig.Set(key, defaultValue)
+					end
+				end
+
 				count = count + 1
 			end
 
-			local rect = GUI.RectTransform(Vector2(1, 0.05), list.Content.RectTransform)
-			local textBlock = GUI.TextBlock(
-				rect,
-				entry.name .. " (" .. minrange .. "-" .. maxrange .. ")",
-				Color(230, 230, 170),
-				nil,
-				GUI.Alignment.Center,
-				true,
-				nil,
-				Color(0, 0, 0)
-			)
-			if entry.description then
-				textBlock.ToolTip = entry.description
-			end
-			local scalar =
-				GUI.NumberInput(GUI.RectTransform(Vector2(1, 0.08), list.Content.RectTransform), NumberType.Float)
-			local key2 = key
-			scalar.valueStep = 0.1
-			scalar.MinValueFloat = 0
-			scalar.MaxValueFloat = 100
-			if entry.range then
-				scalar.MinValueFloat = entry.range[1]
-				scalar.MaxValueFloat = entry.range[2]
-			end
-			scalar.FloatValue = NTConfig.Get(key2, 1)
-			scalar.OnValueChanged = function()
-				NTConfig.Set(key2, scalar.FloatValue)
-				OnChanged()
-			end
-		elseif entry.type == "string" then
-			--user string input
-			local style = ""
-			--get custom style
-			if entry.style ~= nil then
-				style = " (" .. entry.style .. ")"
-			end
+		-- Grouped Strings
+		elseif chunk.type == "string_group" then
+			local MaxPerRow = 2
+			local row = nil
+			local count = 0
 
-			local rect = GUI.RectTransform(Vector2(1, 0.05), list.Content.RectTransform)
-			local textBlock = GUI.TextBlock(
-				rect,
-				entry.name .. style,
-				Color(230, 230, 170),
-				nil,
-				GUI.Alignment.Center,
-				true,
-				nil,
-				Color(0, 0, 0)
-			)
-			if entry.description then
-				textBlock.ToolTip = entry.description
-			end
+			for _, item in ipairs(chunk.items) do
+				-- Make a new LayoutGroup to add entries into everytime the MaxPerRow is hit (default of 2)
+				if not row or (count % MaxPerRow == 0) then
+					row = GUI.LayoutGroup(GUI.RectTransform(Vector2(1, 0.09), list.Content.RectTransform), true)
+				end
 
-			local stringinput = MultiLineTextBox(list.Content.RectTransform, "", entry.boxsize)
+				-- Safety check!
+				if not row then 
+					return 
+				end
+				
+				row.RelativeSpacing = 0.01
 
-			stringinput.Text = table.concat(entry.value, ",")
+				local Text_space = 0.50
+				-- Any less than 0.33 per string and the max value (255,255,255) or 3 digits per value will bleed (at 1920 * 1080 default)
+				local String_space = 0.33
+				local Reset_space = 0.07 
 
-			stringinput.OnTextChangedDelegate = function(textBox)
-				entry.value = CommaStringToTable(textBox.Text)
+				local baseWidth = 1 / MaxPerRow
+
+				local textcellwidth   = baseWidth * Text_space
+				local scalarcellwidth = baseWidth * String_space
+				local resetcellwidth  = baseWidth * Reset_space
+
+				local key = item.key
+				local entry = item.entry
+				local resetButton
+
+
+				-- Make each subdivided part of the group their own
+				-- Part of the group that holds text
+				local textcell = GUI.LayoutGroup(GUI.RectTransform(Vector2(textcellwidth, 1), row.RectTransform), false)
+				-- Part of the group that holds the input box
+				local stringinputcell = GUI.LayoutGroup(GUI.RectTransform(Vector2(scalarcellwidth, 1), row.RectTransform), false)
+				-- In case a reset button is set
+				local resetbuttoncell = GUI.LayoutGroup(GUI.RectTransform(Vector2(resetcellwidth, 0.45), row.RectTransform), false)
+				-- Relativespacing but larger space for the center instead of everywhere
+				local additionalspacecell = GUI.LayoutGroup(GUI.RectTransform(Vector2(resetcellwidth, 0.59), row.RectTransform), false)
+
+				local style = ""
+				if entry.style ~= nil then
+					style = " (" .. entry.style .. ")"
+				end
+
+				local tb_StringInformation = GUI.TextBlock(
+					GUI.RectTransform(Vector2(1, 0.4), textcell.RectTransform),
+					entry.name .. style,
+					DefaultTextColour,
+					nil,
+					GUI.Alignment.Center,
+					true,
+					nil,
+					Transparent
+				)
+
+				tb_StringInformation.CanBeFocused = false
+
+				if entry.description then
+					tb_StringInformation.ToolTip = entry.description
+					tb_StringInformation.CanBeFocused = true
+				end
+
+				local stringinput
+
+				-- Not all strings need a MultiLineTextBox, especially since they can just yoink the mouse cursor while scrolling.
+				-- Make MLTB's a toggleable option
+				if entry.noMLTB == true then
+					stringinput = GUI.TextBox(GUI.RectTransform(Vector2(1, entry.boxsize), stringinputcell.RectTransform, GUI.Anchor.CenterLeft), "", nil, nil, nil, true)
+				else
+					stringinput = MultiLineTextBox(stringinputcell.RectTransform, "", (entry.boxsize))
+				end
+
+				stringinput.Text = table.concat(entry.value, ",")
+
+				stringinput.OnTextChangedDelegate = function(textBox)
+					entry.value = CommaStringToTable(textBox.Text)
+				end
+
+				-- Leftover space in the Row goes to the reset button if enabled
+				if entry.resettable then 
+					resetButton = GUI.Button(GUI.RectTransform(Vector2(1, 1), resetbuttoncell.RectTransform), GUI.Alignment.CenterRight, nil, Transparent)
+					-- Give the reset button a sprite that matches its function (yoinked from basegame)
+					local resetButtonStyle = GUI.Image(GUI.RectTransform(Vector2(1, 1), resetButton.RectTransform), "GUIButtonRefresh")
+					resetButtonStyle.ToolTip = "Reset to default"
+					
+					-- On button press, fetch default value.
+					resetButton.OnClicked = function()
+						entry.value = entry.default
+						stringinput.Text = table.concat(entry.value, ",")
+					end
+				end
+
+				count = count + 1
 			end
-		elseif entry.type == "bool" then
-			-- toggle
-			local rect = GUI.RectTransform(Vector2(1, 0.2), list.Content.RectTransform)
-			local toggle = GUI.TickBox(rect, entry.name)
-			if entry.description then
-				toggle.ToolTip = entry.description
-			end
-			local key2 = key
-			toggle.Selected = NTConfig.Get(key2, false)
-			toggle.OnSelected = function()
-				NTConfig.Set(key2, toggle.State == GUIComponent.ComponentState.Selected)
-				OnChanged()
-			end
-		elseif entry.type == "category" then
-			-- Change visual separation to subheader
-			GUI.TextBlock(
-				GUI.RectTransform(Vector2(1, 0.10), list.Content.RectTransform),
-				entry.name,
-				Color(255, 255, 237),
-				GUI.GUIStyle.SubHeadingFont,
-				GUI.Alignment.Center,
-				true,
-				nil,
-				Color(0, 0, 0)
-			)
 		end
 	end
 
@@ -210,12 +463,59 @@ local function ConstructUI(parent)
 	return list
 end
 
+-- Base UI construction
+local function ConstructUI(parent)
+	-- Set the default to display (Neurotrauma, duh)
+	local selectedExpansion = "Neurotrauma"
+	local list = easySettings.BasicList(parent)
+
+	-- Get the Title block to put the drop down menu into (could be moved tbh)
+	local innerLayout = list.Parent
+	local children = innerLayout.RectTransform.Children
+	local title = children[1].GUIComponent
+
+	-- Get the amount of loaded expansions
+	local dropdownheight = #NTConfig.Expansions
+
+	-- Don't show the dropdown if we only have Neurotrauma or no other addons that have settings to show
+	if dropdownheight > 1 then
+		local dropdown_AddonSelection = GUI.DropDown(GUI.RectTransform(Vector2(0.18, 1), title.RectTransform), "", dropdownheight - 2, nil, false, false, GUI.Alignment.CenterLeft)
+		dropdown_AddonSelection.ListBox.RectTransform.RelativeOffset = (Vector2(0, 0.5))
+		PopulateDropdown(dropdown_AddonSelection)
+		dropdown_AddonSelection.Select(0)
+		dropdown_AddonSelection.ToolTip = "Choose which mod's settings to display."
+
+		-- Using the dropdown changes a variable so we can change the page accordingly; only do so if we're not already on that page
+		dropdown_AddonSelection.OnSelected = function(guiComponent)
+			local newSelection = tostring(guiComponent.Text)
+
+			-- Check if changed
+			if newSelection == selectedExpansion then
+				return
+			end
+
+			selectedExpansion  = newSelection
+
+			-- Redo content based on new selection
+			PopulateSettingsIntoUI(list, selectedExpansion)
+		end
+	end
+
+	-- Default
+	PopulateSettingsIntoUI(list, selectedExpansion)
+end
+
 Networking.Receive("NT.ConfigUpdate", function(msg)
 	NTConfig.ReceiveConfig(msg)
-	local parent = configUI.Parent.Parent.Parent.Parent.Parent
-	configUI.RectTransform.Parent.Parent.Parent.Parent = nil
-	configUI = nil
-	configUI = ConstructUI(parent)
+
+    if configUI == nil then return end
+    if configUI.RectTransform == nil then return end
+
+    local parent = configUI.RectTransform.Parent
+
+    configUI = nil
+
+    configUI = ConstructUI(parent)
 end)
 
 easySettings.AddMenu("Neurotrauma", function(parent)

--- a/Neurotrauma/Lua/Scripts/Client/easysettings.lua
+++ b/Neurotrauma/Lua/Scripts/Client/easysettings.lua
@@ -32,35 +32,47 @@ end
 
 -- Overhauled Config GUI
 easySettings.BasicList = function(parent, size)
-    -- Menu Frame
-    local menuContent = GUI.Frame(GUI.RectTransform(size or Vector2(0.5, 0.8), parent.RectTransform, GUI.Anchor.Center), "GUIFrame")
+	-- Menu Frame
+	local menuContent =
+		GUI.Frame(GUI.RectTransform(size or Vector2(0.5, 0.8), parent.RectTransform, GUI.Anchor.Center), "GUIFrame")
 
-    -- Main Layout
-    local mainLayout = GUI.LayoutGroup(GUI.RectTransform(Vector2(0.95, 0.95), menuContent.RectTransform, GUI.Anchor.Center, GUI.Pivot.Center), false)
+	-- Main Layout
+	local mainLayout = GUI.LayoutGroup(
+		GUI.RectTransform(Vector2(0.95, 0.95), menuContent.RectTransform, GUI.Anchor.Center, GUI.Pivot.Center),
+		false
+	)
 
-    -- Background 
-    local configBackground = GUI.Frame(GUI.RectTransform(Vector2(1, 0.95), mainLayout.RectTransform), "InnerFrame")
+	-- Background
+	local configBackground = GUI.Frame(GUI.RectTransform(Vector2(1, 0.95), mainLayout.RectTransform), "InnerFrame")
 
-    -- Shrink Inner layout 
-    local innerLayout = GUI.LayoutGroup(GUI.RectTransform(Vector2(0.95, 0.95), configBackground.RectTransform, GUI.Anchor.TopCenter), false)
+	-- Shrink Inner layout
+	local innerLayout = GUI.LayoutGroup(
+		GUI.RectTransform(Vector2(0.95, 0.95), configBackground.RectTransform, GUI.Anchor.TopCenter),
+		false
+	)
 
-    -- Title block
-    local title = GUI.TextBlock(GUI.RectTransform(Vector2(1, 0.07), innerLayout.RectTransform), "Neurotrauma Config Settings", nil, GUI.GUIStyle.LargeFont)
-    title.TextAlignment = GUI.Alignment.TopCenter
+	-- Title block
+	local title = GUI.TextBlock(
+		GUI.RectTransform(Vector2(1, 0.07), innerLayout.RectTransform),
+		"Neurotrauma Config Settings",
+		nil,
+		GUI.GUIStyle.LargeFont
+	)
+	title.TextAlignment = GUI.Alignment.TopCenter
 
-    -- Setting list
-    local menuList = GUI.ListBox(GUI.RectTransform(Vector2(1, 0.97), innerLayout.RectTransform))
-    menuList.Padding = Vector4(10, 15, 10, 10)
-    menuList.UpdateDimensions()
+	-- Setting list
+	local menuList = GUI.ListBox(GUI.RectTransform(Vector2(1, 0.97), innerLayout.RectTransform))
+	menuList.Padding = Vector4(10, 15, 10, 10)
+	menuList.UpdateDimensions()
 
-    -- Button row
-    local buttonRow = GUI.LayoutGroup(GUI.RectTransform(Vector2(1, 0.1), mainLayout.RectTransform), true)
-    buttonRow.RelativeSpacing = 0.02
-    easySettings.SaveButton(buttonRow)
-    easySettings.CloseButton(buttonRow)
-    easySettings.ResetButton(buttonRow)
+	-- Button row
+	local buttonRow = GUI.LayoutGroup(GUI.RectTransform(Vector2(1, 0.1), mainLayout.RectTransform), true)
+	buttonRow.RelativeSpacing = 0.02
+	easySettings.SaveButton(buttonRow)
+	easySettings.CloseButton(buttonRow)
+	easySettings.ResetButton(buttonRow)
 
-    return menuList
+	return menuList
 end
 
 -- Function for a Tickbox
@@ -92,7 +104,12 @@ end
 
 -- Function for the Save and Exit button
 easySettings.SaveButton = function(parent)
-	local button = GUI.Button(GUI.RectTransform(Vector2(0.32, 0.05), parent.RectTransform, GUI.Anchor.BottomLeft), "Save and Exit", GUI.Alignment.Center, "GUIButton")
+	local button = GUI.Button(
+		GUI.RectTransform(Vector2(0.32, 0.05), parent.RectTransform, GUI.Anchor.BottomLeft),
+		"Save and Exit",
+		GUI.Alignment.Center,
+		"GUIButton"
+	)
 
 	button.OnClicked = function()
 		if Game.IsMultiplayer and Game.Client.HasPermission(ClientPermissions.ManageSettings) then
@@ -108,7 +125,12 @@ end
 
 -- Function for the Discard and Exit button
 easySettings.CloseButton = function(parent)
-	local button = GUI.Button(GUI.RectTransform(Vector2(0.32, 0.05), parent.RectTransform, GUI.Anchor.BottomCenter), "Discard and Exit", GUI.Alignment.Center, "GUIButton")
+	local button = GUI.Button(
+		GUI.RectTransform(Vector2(0.32, 0.05), parent.RectTransform, GUI.Anchor.BottomCenter),
+		"Discard and Exit",
+		GUI.Alignment.Center,
+		"GUIButton"
+	)
 
 	button.OnClicked = function()
 		GUI.GUI.TogglePauseMenu()
@@ -120,7 +142,12 @@ end
 
 -- Function for the Reset and Exit button
 easySettings.ResetButton = function(parent)
-	local button = GUI.Button(GUI.RectTransform(Vector2(0.32, 0.05), parent.RectTransform, GUI.Anchor.BottomRight), "Reset Config", GUI.Alignment.Center, "GUIButton")
+	local button = GUI.Button(
+		GUI.RectTransform(Vector2(0.32, 0.05), parent.RectTransform, GUI.Anchor.BottomRight),
+		"Reset Config",
+		GUI.Alignment.Center,
+		"GUIButton"
+	)
 
 	button.OnClicked = function()
 		if
@@ -169,7 +196,12 @@ Hook.Patch("Barotrauma.GUI", "TogglePauseMenu", {}, function()
 		local list = GetChildren(GetChildren(frame)[2])[1]
 
 		for key, value in pairs(easySettings.Settings) do
-			local PauseMenuButton = GUI.Button(GUI.RectTransform(Vector2(1, 0.1), list.RectTransform), value.Name, GUI.Alignment.Center, "GUIButtonSmall")
+			local PauseMenuButton = GUI.Button(
+				GUI.RectTransform(Vector2(1, 0.1), list.RectTransform),
+				value.Name,
+				GUI.Alignment.Center,
+				"GUIButtonSmall"
+			)
 
 			PauseMenuButton.OnClicked = function()
 				value.OnOpen(frame)

--- a/Neurotrauma/Lua/Scripts/Client/easysettings.lua
+++ b/Neurotrauma/Lua/Scripts/Client/easysettings.lua
@@ -1,5 +1,5 @@
---original code by Evil Factory,
---adapted to NT
+-- Original code by Evil Factory,
+-- Adapted for Neurotrauma
 local easySettings = {}
 
 easySettings.Settings = {}
@@ -14,30 +14,10 @@ local function GetChildren(comp)
 	return tbl
 end
 
-Hook.Patch("Barotrauma.GUI", "TogglePauseMenu", {}, function()
-	if GUI.GUI.PauseMenuOpen then
-		local frame = GUI.GUI.PauseMenu
-
-		local list = GetChildren(GetChildren(frame)[2])[1]
-
-		for key, value in pairs(easySettings.Settings) do
-			local button = GUI.Button(
-				GUI.RectTransform(Vector2(1, 0.1), list.RectTransform),
-				value.Name,
-				GUI.Alignment.Center,
-				"GUIButtonSmall"
-			)
-
-			button.OnClicked = function()
-				value.OnOpen(frame)
-			end
-		end
-	end
-end, Hook.HookMethodType.After)
-
 easySettings.SaveTable = function(path, tbl)
 	File.Write(path, json.serialize(tbl))
 end
+
 easySettings.LoadTable = function(path)
 	if not File.Exists(path) then
 		return {}
@@ -53,7 +33,7 @@ end
 -- Overhauled Config GUI
 easySettings.BasicList = function(parent, size)
     -- Menu Frame
-    local menuContent = GUI.Frame(GUI.RectTransform(size or Vector2(0.4, 0.7), parent.RectTransform, GUI.Anchor.Center), "GUIFrame")
+    local menuContent = GUI.Frame(GUI.RectTransform(size or Vector2(0.5, 0.8), parent.RectTransform, GUI.Anchor.Center), "GUIFrame")
 
     -- Main Layout
     local mainLayout = GUI.LayoutGroup(GUI.RectTransform(Vector2(0.95, 0.95), menuContent.RectTransform, GUI.Anchor.Center, GUI.Pivot.Center), false)
@@ -83,6 +63,7 @@ easySettings.BasicList = function(parent, size)
     return menuList
 end
 
+-- Function for a Tickbox
 easySettings.TickBox = function(parent, text, onSelected, state)
 	if state == nil then
 		state = true
@@ -97,6 +78,7 @@ easySettings.TickBox = function(parent, text, onSelected, state)
 	return tickBox
 end
 
+-- Function for a Slider
 easySettings.Slider = function(parent, min, max, onSelected, value)
 	local scrollBar = GUI.ScrollBar(GUI.RectTransform(Vector2(1, 0.1), parent.RectTransform), 0.1, nil, "GUISlider")
 	scrollBar.Range = Vector2(min, max)
@@ -108,14 +90,9 @@ easySettings.Slider = function(parent, min, max, onSelected, value)
 	return scrollBar
 end
 
---save and exit
+-- Function for the Save and Exit button
 easySettings.SaveButton = function(parent)
-	local button = GUI.Button(
-		GUI.RectTransform(Vector2(0.32, 0.05), parent.RectTransform, GUI.Anchor.BottomLeft),
-		"Save and Exit",
-		GUI.Alignment.Center,
-		"GUIButton"
-	)
+	local button = GUI.Button(GUI.RectTransform(Vector2(0.32, 0.05), parent.RectTransform, GUI.Anchor.BottomLeft), "Save and Exit", GUI.Alignment.Center, "GUIButton")
 
 	button.OnClicked = function()
 		if Game.IsMultiplayer and Game.Client.HasPermission(ClientPermissions.ManageSettings) then
@@ -129,14 +106,9 @@ easySettings.SaveButton = function(parent)
 	return button
 end
 
---discard and exit
+-- Function for the Discard and Exit button
 easySettings.CloseButton = function(parent)
-	local button = GUI.Button(
-		GUI.RectTransform(Vector2(0.32, 0.05), parent.RectTransform, GUI.Anchor.BottomCenter),
-		"Discard and Exit",
-		GUI.Alignment.Center,
-		"GUIButton"
-	)
+	local button = GUI.Button(GUI.RectTransform(Vector2(0.32, 0.05), parent.RectTransform, GUI.Anchor.BottomCenter), "Discard and Exit", GUI.Alignment.Center, "GUIButton")
 
 	button.OnClicked = function()
 		GUI.GUI.TogglePauseMenu()
@@ -146,14 +118,9 @@ easySettings.CloseButton = function(parent)
 	return button
 end
 
---reset and exit
+-- Function for the Reset and Exit button
 easySettings.ResetButton = function(parent)
-	local button = GUI.Button(
-		GUI.RectTransform(Vector2(0.32, 0.05), parent.RectTransform, GUI.Anchor.BottomRight),
-		"Reset Config",
-		GUI.Alignment.Center,
-		"GUIButton"
-	)
+	local button = GUI.Button(GUI.RectTransform(Vector2(0.32, 0.05), parent.RectTransform, GUI.Anchor.BottomRight), "Reset Config", GUI.Alignment.Center, "GUIButton")
 
 	button.OnClicked = function()
 		if
@@ -162,9 +129,11 @@ easySettings.ResetButton = function(parent)
 			easySettings.ResetMessage(parent)
 		end
 	end
+
 	return button
 end
 
+-- Confirmation popup for config reset
 easySettings.ResetMessage = function(parent)
 	local ResetMessage = GUI.MessageBox(
 		"Reset neurotrauma settings",
@@ -173,6 +142,7 @@ easySettings.ResetMessage = function(parent)
 	)
 	ResetMessage.DrawOnTop = true
 	ResetMessage.Text.TextAlignment = GUI.Alignment.Center
+
 	ResetMessage.Buttons[1].OnClicked = function()
 		NTConfig.ResetConfig()
 		if Game.IsMultiplayer and Game.Client.HasPermission(ClientPermissions.ManageSettings) then
@@ -183,10 +153,29 @@ easySettings.ResetMessage = function(parent)
 		GUI.GUI.TogglePauseMenu()
 		ResetMessage.Close()
 	end
+
 	ResetMessage.Buttons[2].OnClicked = function()
 		ResetMessage.Close()
 	end
+
 	return ResetMessage
 end
+
+-- Add button on pause menu for NT Settings
+Hook.Patch("Barotrauma.GUI", "TogglePauseMenu", {}, function()
+	if GUI.GUI.PauseMenuOpen then
+		local frame = GUI.GUI.PauseMenu
+
+		local list = GetChildren(GetChildren(frame)[2])[1]
+
+		for key, value in pairs(easySettings.Settings) do
+			local PauseMenuButton = GUI.Button(GUI.RectTransform(Vector2(1, 0.1), list.RectTransform), value.Name, GUI.Alignment.Center, "GUIButtonSmall")
+
+			PauseMenuButton.OnClicked = function()
+				value.OnOpen(frame)
+			end
+		end
+	end
+end, Hook.HookMethodType.After)
 
 return easySettings

--- a/Neurotrauma/Lua/Scripts/configdata.lua
+++ b/Neurotrauma/Lua/Scripts/configdata.lua
@@ -3,13 +3,15 @@ NTConfig = { Entries = {}, Expansions = {} } -- contains all config options, the
 local configDirectoryPath = Game.SaveFolder .. "/ModConfigs"
 local configFilePath = configDirectoryPath .. "/Neurotrauma.json"
 
--- this is the function that gets used in other mods to add their own settings to the config
+-- This is the function that gets used in other mods to add their own settings to the config
 function NTConfig.AddConfigOptions(expansion)
 	table.insert(NTConfig.Expansions, expansion)
 
 	for key, entry in pairs(expansion.ConfigData) do
 		NTConfig.Entries[key] = entry
 		NTConfig.Entries[key].value = entry.default
+		-- Inject the Expansion of origin into config entries 
+		entry.expansion = expansion.Name
 	end
 end
 
@@ -91,7 +93,10 @@ function NTConfig.ReceiveConfig(msg)
 end
 
 NT.ConfigData = {
-	NT_header1 = { name = "Neurotrauma", type = "category" },
+	NT_header1 = { 
+		name = "Neurotrauma", 
+		type = "category" 
+	},
 
 	NT_dislocationChance = {
 		name = "Dislocation chance",
@@ -99,91 +104,130 @@ NT.ConfigData = {
 		range = { 0, 100 },
 		type = "float",
 		difficultyCharacteristics = { max = 5 },
+		group = true,
+		resettable = true,
 	},
+
 	NT_fractureChance = {
 		name = "Fracture chance",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
 		difficultyCharacteristics = { multiplier = 2, max = 5 },
+		group = true,
+		resettable = true,
 	},
+
 	NT_pneumothoraxChance = {
 		name = "Pneumothorax chance",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
 		difficultyCharacteristics = { max = 5 },
+		group = true,
+		resettable = true,
 	},
+
 	NT_tamponadeChance = {
 		name = "Tamponade chance",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
 		difficultyCharacteristics = { max = 3 },
+		group = true,
+		resettable = true,
 	},
+
 	NT_heartattackChance = {
 		name = "Heart attack chance",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
 		difficultyCharacteristics = { multiplier = 0.5, max = 1 },
+		group = true,
+		resettable = true,
 	},
+
 	NT_strokeChance = {
 		name = "Stroke chance",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
 		difficultyCharacteristics = { multiplier = 0.5, max = 1 },
+		group = true,
+		resettable = true,
 	},
+
 	NT_infectionRate = {
 		name = "Infection rate",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
 		difficultyCharacteristics = { multiplier = 1.5, max = 5 },
+		group = true,
+		resettable = true,
 	},
+
 	NT_CPRFractureChance = {
 		name = "CPR fracture chance",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
 		difficultyCharacteristics = { multiplier = 0.5, max = 1 },
+		group = true,
+		resettable = true,
 	},
+
 	NT_traumaticAmputationChance = {
 		name = "Traumatic amputation chance",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
 		difficultyCharacteristics = { max = 3 },
+		group = true,
+		resettable = true,
 	},
+
 	NT_neurotraumaGain = {
 		name = "Neurotrauma gain",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
 		difficultyCharacteristics = { multiplier = 3, max = 10 },
+		group = true,
+		resettable = true,
 	},
+
 	NT_organDamageGain = {
 		name = "Organ damage gain",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
 		difficultyCharacteristics = { multiplier = 2, max = 8 },
+		group = true,
+		resettable = true,
 	},
+
 	NT_fibrillationSpeed = {
 		name = "Fibrillation rate",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
 		difficultyCharacteristics = { multiplier = 1.5, max = 8 },
+		group = true,
+		resettable = true,
 	},
+
 	NT_gangrenespeed = {
 		name = "Gangrene rate",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
 		difficultyCharacteristics = { multiplier = 0.5, max = 5 },
+		group = true,
+		resettable = true,
 	},
+
 	--NT_velocityWeight = {
 	--	name = "Velocity weight",
 	--	default = 1,
@@ -192,52 +236,72 @@ NT.ConfigData = {
 	--	difficultyCharacteristics = { multiplier = 0.5, max = 5 },
 	--	description = "How much fall velocity is allowed for sharing damage into other limbs.",
 	--},
+
 	NT_falldamageCeiling = {
 		name = "Maximum fall damage",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
 		difficultyCharacteristics = { multiplier = 0.5, max = 5 },
+		group = true,
+		resettable = true,
 	},
+
 	NT_falldamage = {
 		name = "Falldamage",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
 		difficultyCharacteristics = { multiplier = 0.5, max = 5 },
+		group = true,
+		resettable = true,
 	},
+
 	NT_falldamageSeriousInjuryChance = {
 		name = "Falldamage serious injury chance",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
 		difficultyCharacteristics = { multiplier = 0.5, max = 5 },
+		group = true,
+		resettable = true,
 	},
+	
 	NT_Calculations = {
 		name = "Enable character calculations",
 		default = true,
 		type = "bool",
 		description = "Runs various calculations necessary for the functionality of the mod. Shouldn't be disabled unless the server is dying.",
 	},
+
 	NT_vanillaSkillCheck = {
 		name = "Vanilla skill check formula",
 		default = false,
 		type = "bool",
 		description = "Changes the chance to succeed a lua skillcheck from skill/requiredskill to 100-(requiredskill-skill))/100 .",
 	},
+
 	NT_disableBotAlgorithms = {
 		name = "Disable bot treatment algorithms",
 		default = true,
 		type = "bool",
 		description = "Prevents bots from attempting to treat afflictions.\nThis is desireable, because bots suck at treating things, and their bad attempts lag out the game immensely.",
 	},
-	NT_screams = { name = "Screams", default = true, type = "bool", description = "Characters scream when in pain." },
+
+	NT_screams = { 
+		name = "Screams", 
+		default = true, 
+		type = "bool", 
+		description = "Characters scream when in pain." 
+	},
+
 	NT_ignoreModConflicts = {
 		name = "Ignore mod conflicts",
 		default = false,
 		type = "bool",
 		description = "Prevent the mod conflict affliction from showing up.",
 	},
+
 	NT_organRejection = {
 		name = "Organ rejection",
 		default = false,
@@ -245,6 +309,7 @@ NT.ConfigData = {
 		difficultyCharacteristics = { multiplier = 0.5 },
 		description = "When transplanting an organ, there is a chance that the organ gets rejected.\nThe higher the patients immunity at the time of the transplant, the higher the chance.",
 	},
+
 	NT_fracturesRemoveCasts = {
 		name = "Fractures remove casts",
 		default = true,
@@ -252,6 +317,7 @@ NT.ConfigData = {
 		difficultyCharacteristics = { multiplier = 0.5 },
 		description = "When receiving damage that would cause a fracture, remove plaster casts on the limb",
 	},
+
 	NT_creatureNoFallDamage = {
 		name = "Excluded creatures that abuse the fall damage mechanic",
 		default = {
@@ -266,7 +332,11 @@ NT.ConfigData = {
 		description = "You can add or remove creatures to customize this list to your liking. Use debug command `nt_listcreatures` to list the SpeciesName of the creature you are patching in your game. Report creatures that abuse fall damage to the discord server to improve this default list.",
 	},
 
-	NTCRE_header1 = { name = "Consent Required", type = "category" },
+	NTCRE_header1 = { 
+		name = "Consent Required", 
+		type = "category" 
+	},
+
 	NTCRE_ConsentRequiredExtra = {
 		name = "Consent Required",
 		default = false,
@@ -289,6 +359,7 @@ NT.ConfigData = {
 		range = { 0, 100 },
 		type = "float",
 		description = "Where the Low progress color ends and Medium progress color begins.",
+		group = true
 	},
 
 	NT_medhighThreshold = {
@@ -297,6 +368,7 @@ NT.ConfigData = {
 		range = { 0, 100 },
 		type = "float",
 		description = "Where the Medium progress color ends and High progress color begins.",
+		group = true
 	},
 
 	NTSCAN_basecolor = {
@@ -306,6 +378,9 @@ NT.ConfigData = {
 		type = "string",
 		boxsize = 0.05,
 		description = "Scanner text color.",
+		noMLTB = true,
+		group = true,
+		resettable = true,
 	},
 
 	NTSCAN_namecolor = {
@@ -315,6 +390,9 @@ NT.ConfigData = {
 		type = "string",
 		boxsize = 0.05,
 		description = "Scanner text color for player names.",
+		noMLTB = true,
+		group = true,
+		resettable = true,
 	},
 
 	NTSCAN_lowcolor = {
@@ -324,6 +402,9 @@ NT.ConfigData = {
 		type = "string",
 		boxsize = 0.05,
 		description = "Scanner text color for afflictions that have low progress.",
+		noMLTB = true,
+		group = true,
+		resettable = true,
 	},
 
 	NTSCAN_medcolor = {
@@ -333,6 +414,9 @@ NT.ConfigData = {
 		type = "string",
 		boxsize = 0.05,
 		description = "Scanner text color for afflictions that have medium progress.",
+		noMLTB = true,
+		group = true,
+		resettable = true,
 	},
 
 	NTSCAN_highcolor = {
@@ -342,6 +426,9 @@ NT.ConfigData = {
 		type = "string",
 		boxsize = 0.05,
 		description = "Scanner text color for afflictions that have high progress.",
+		noMLTB = true,
+		group = true,
+		resettable = true,
 	},
 	NTSCAN_vitalcolor = {
 		name = "Vital Priority Color",
@@ -350,6 +437,9 @@ NT.ConfigData = {
 		type = "string",
 		boxsize = 0.05,
 		description = "Scanner text color for vital afflictions (Arterial bleed, Traumatic amputation).",
+		noMLTB = true,
+		group = true,
+		resettable = true,
 	},
 	NTSCAN_removalcolor = {
 		name = "Removed Organ Color",
@@ -358,6 +448,9 @@ NT.ConfigData = {
 		type = "string",
 		boxsize = 0.05,
 		description = "Scanner text color for removed organs (Heart removed, leg amputation).",
+		noMLTB = true,
+		group = true,
+		resettable = true,
 	},
 	NTSCAN_customcolor = {
 		name = "Custom Category Color",
@@ -366,6 +459,9 @@ NT.ConfigData = {
 		type = "string",
 		boxsize = 0.05,
 		description = "Scanner text color for the custom category.",
+		noMLTB = true,
+		group = true,
+		resettable = true,
 	},
 
 	NTSCAN_VitalCategory = {
@@ -428,6 +524,7 @@ NT.ConfigData = {
 		description = "Afflictions added to this category will be ignored by the health scanner.",
 	},
 }
+
 NTConfig.AddConfigOptions(NT)
 
 -- wait a bit before loading the config so all options have had time to be added

--- a/Neurotrauma/Lua/Scripts/configdata.lua
+++ b/Neurotrauma/Lua/Scripts/configdata.lua
@@ -10,7 +10,7 @@ function NTConfig.AddConfigOptions(expansion)
 	for key, entry in pairs(expansion.ConfigData) do
 		NTConfig.Entries[key] = entry
 		NTConfig.Entries[key].value = entry.default
-		-- Inject the Expansion of origin into config entries 
+		-- Inject the Expansion of origin into config entries
 		entry.expansion = expansion.Name
 	end
 end
@@ -93,9 +93,9 @@ function NTConfig.ReceiveConfig(msg)
 end
 
 NT.ConfigData = {
-	NT_header1 = { 
-		name = "Neurotrauma", 
-		type = "category" 
+	NT_header1 = {
+		name = "Neurotrauma",
+		type = "category",
 	},
 
 	NT_dislocationChance = {
@@ -266,7 +266,7 @@ NT.ConfigData = {
 		group = true,
 		resettable = true,
 	},
-	
+
 	NT_Calculations = {
 		name = "Character calculations",
 		default = true,
@@ -288,11 +288,11 @@ NT.ConfigData = {
 		description = "Prevents bots from attempting to treat afflictions.\nThis is desireable, because bots suck at treating things for the current moment.",
 	},
 
-	NT_screams = { 
-		name = "Screams", 
-		default = true, 
-		type = "bool", 
-		description = "Characters scream when in pain." 
+	NT_screams = {
+		name = "Screams",
+		default = true,
+		type = "bool",
+		description = "Characters scream when in pain.",
 	},
 
 	NT_ignoreModConflicts = {
@@ -317,7 +317,7 @@ NT.ConfigData = {
 		difficultyCharacteristics = { multiplier = 0.5 },
 		description = "When receiving damage that would cause a fracture, remove plaster casts on the limb",
 	},
-	
+
 	NTCRE_ConsentRequiredExtra = {
 		name = "NPCs consent requirement to medical interactions",
 		default = false,
@@ -354,7 +354,7 @@ NT.ConfigData = {
 		range = { 0, 100 },
 		type = "float",
 		description = "Where the Low progress color ends and Medium progress color begins.",
-		group = true
+		group = true,
 	},
 
 	NT_medhighThreshold = {
@@ -363,7 +363,7 @@ NT.ConfigData = {
 		range = { 0, 100 },
 		type = "float",
 		description = "Where the Medium progress color ends and High progress color begins.",
-		group = true
+		group = true,
 	},
 
 	NTSCAN_basecolor = {

--- a/Neurotrauma/Lua/Scripts/configdata.lua
+++ b/Neurotrauma/Lua/Scripts/configdata.lua
@@ -99,7 +99,7 @@ NT.ConfigData = {
 	},
 
 	NT_dislocationChance = {
-		name = "Dislocation chance",
+		name = "Dislocation chance multiplier",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
@@ -109,7 +109,7 @@ NT.ConfigData = {
 	},
 
 	NT_fractureChance = {
-		name = "Fracture chance",
+		name = "Fracture chance multiplier",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
@@ -119,7 +119,7 @@ NT.ConfigData = {
 	},
 
 	NT_pneumothoraxChance = {
-		name = "Pneumothorax chance",
+		name = "Pneumothorax chance multiplier",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
@@ -129,7 +129,7 @@ NT.ConfigData = {
 	},
 
 	NT_tamponadeChance = {
-		name = "Tamponade chance",
+		name = "Tamponade chance multiplier",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
@@ -139,7 +139,7 @@ NT.ConfigData = {
 	},
 
 	NT_heartattackChance = {
-		name = "Heart attack chance",
+		name = "Heart attack chance multiplier",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
@@ -149,7 +149,7 @@ NT.ConfigData = {
 	},
 
 	NT_strokeChance = {
-		name = "Stroke chance",
+		name = "Stroke chance multiplier",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
@@ -159,7 +159,7 @@ NT.ConfigData = {
 	},
 
 	NT_infectionRate = {
-		name = "Infection rate",
+		name = "Infection rate multiplier",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
@@ -169,7 +169,7 @@ NT.ConfigData = {
 	},
 
 	NT_CPRFractureChance = {
-		name = "CPR fracture chance",
+		name = "CPR fracture chance multiplier",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
@@ -179,7 +179,7 @@ NT.ConfigData = {
 	},
 
 	NT_traumaticAmputationChance = {
-		name = "Traumatic amputation chance",
+		name = "Traumatic amputation chance multiplier",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
@@ -189,7 +189,7 @@ NT.ConfigData = {
 	},
 
 	NT_neurotraumaGain = {
-		name = "Neurotrauma gain",
+		name = "Neurotrauma gain rate",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
@@ -199,7 +199,7 @@ NT.ConfigData = {
 	},
 
 	NT_organDamageGain = {
-		name = "Organ damage gain",
+		name = "Organ damage gain rate",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
@@ -209,7 +209,7 @@ NT.ConfigData = {
 	},
 
 	NT_fibrillationSpeed = {
-		name = "Fibrillation rate",
+		name = "Fibrillation gain rate",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
@@ -219,7 +219,7 @@ NT.ConfigData = {
 	},
 
 	NT_gangrenespeed = {
-		name = "Gangrene rate",
+		name = "Gangrene gain rate",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
@@ -238,7 +238,7 @@ NT.ConfigData = {
 	--},
 
 	NT_falldamageCeiling = {
-		name = "Maximum fall damage",
+		name = "Maximum fall damage multiplier",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
@@ -248,7 +248,7 @@ NT.ConfigData = {
 	},
 
 	NT_falldamage = {
-		name = "Falldamage",
+		name = "Falldamage multiplier",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
@@ -258,7 +258,7 @@ NT.ConfigData = {
 	},
 
 	NT_falldamageSeriousInjuryChance = {
-		name = "Falldamage serious injury chance",
+		name = "Falldamage serious injury chance multiplier",
 		default = 1,
 		range = { 0, 100 },
 		type = "float",
@@ -268,10 +268,10 @@ NT.ConfigData = {
 	},
 	
 	NT_Calculations = {
-		name = "Enable character calculations",
+		name = "Character calculations",
 		default = true,
 		type = "bool",
-		description = "Runs various calculations necessary for the functionality of the mod. Shouldn't be disabled unless the server is dying.",
+		description = "Runs calculations that are necessary for the functionality of the mod. Shouldn't be disabled unless there is borderline unplayable desynchronisation and lag, in which case it might help with a bit.",
 	},
 
 	NT_vanillaSkillCheck = {
@@ -285,7 +285,7 @@ NT.ConfigData = {
 		name = "Disable bot treatment algorithms",
 		default = true,
 		type = "bool",
-		description = "Prevents bots from attempting to treat afflictions.\nThis is desireable, because bots suck at treating things, and their bad attempts lag out the game immensely.",
+		description = "Prevents bots from attempting to treat afflictions.\nThis is desireable, because bots suck at treating things for the current moment.",
 	},
 
 	NT_screams = { 
@@ -317,6 +317,13 @@ NT.ConfigData = {
 		difficultyCharacteristics = { multiplier = 0.5 },
 		description = "When receiving damage that would cause a fracture, remove plaster casts on the limb",
 	},
+	
+	NTCRE_ConsentRequiredExtra = {
+		name = "NPCs consent requirement to medical interactions",
+		default = false,
+		type = "bool",
+		description = "Integrated consent required mod.\nIf enabled, NPCs outside of your team or submarine mission will get aggravated by medical interactions.",
+	},
 
 	NT_creatureNoFallDamage = {
 		name = "Excluded creatures that abuse the fall damage mechanic",
@@ -329,25 +336,13 @@ NT.ConfigData = {
 		style = "SpeciesName,SpeciesName",
 		type = "string",
 		boxsize = 0.1,
-		description = "You can add or remove creatures to customize this list to your liking. Use debug command `nt_listcreatures` to list the SpeciesName of the creature you are patching in your game. Report creatures that abuse fall damage to the discord server to improve this default list.",
-	},
-
-	NTCRE_header1 = { 
-		name = "Consent Required", 
-		type = "category" 
-	},
-
-	NTCRE_ConsentRequiredExtra = {
-		name = "Consent Required",
-		default = false,
-		type = "bool",
-		description = "Integrated consent required mod.\nIf enabled, NPCs will get aggravated by medical interactions.",
+		description = "An abuse of fall damage is commonly shown by creatures with heavy or ridicilous knockback, that at worst will instakill or stunlock you.\nYou can add or remove creatures to customize this list to your liking. Use debug command `nt_listcreatures` to list the SpeciesName of the creature you are patching in your game.\nReport other creatures that abuse fall damage to the discord server to improve this default list.",
 	},
 
 	NTSCAN_header1 = { name = "Scanner Settings", type = "category" },
 
 	NTSCAN_enablecoloredscanner = {
-		name = "Enable Colored Scanner",
+		name = "Colored Scanner",
 		default = true,
 		type = "bool",
 		description = "Enable colored health scanner text messages.",


### PR DESCRIPTION
Changes to overhaul the look, readability and ease-of-use of the Neurotrauma Config.
Since they only add on-top and do not totally remove things, this is fully backwards compatible.

By compressing the UI, it makes adding a larger amount of settings possible without forcing players to scroll for a long time and having wasted screen space; likewise, entry-specific reset buttons make editing settings more user friendly - since if they accidentally change the wrong one they can revert it instantly.

### - Changes:
1. Removed Difficulty Calculation (Serves no real purpose, easily re-addable)

2. Config UI is marginally larger (small height increase, width increase)

3. Background colours were equalized, preventing each entry from looking 'blocky' in the background

### - Additions:
1. Scalars / Strings can now be toggled to be 'grouped' and thus render side-by-side with one another, doubling up horizontally. Text is displayed next to the option instead of above it. This decreases the amount of vertical space these settings take up roughly 4 times.

2. Scalars / Strings when grouped have their input area's size reduced by roughly 70% since that was wasted space.

3. Scalars / Strings when grouped can have a 'reset' button added, which resets the value for that specific entry instead of having to rely on resetting the entire config at once.

4. Strings can now be set to no longer be a MultiLineTextblock. While the list entries definitely can use it, not all string entries (for example, the colour coding of the scanner) need to be a MLB; which sometimes creates a scrollbar for a single line of text, preventing you from scrolling further

5. Instead of rendering all settings for all addons / expansions below one another, a dropdown menu was added to allow you to select the mod you want to see the settings for. It does not show up unless at least 1 addon is active that has settings. It automatically ensures uniform text display to make addon names be as close as possible to their Content Package name.

6. Headers are larger and more clearly differentiate categories. Their text colour is now also identical to other entries.

### **Before:**
<img width="820" height="785" alt="image" src="https://github.com/user-attachments/assets/b65dd740-f723-41e2-b953-055e2ca40dd4" />

<img width="820" height="777" alt="image" src="https://github.com/user-attachments/assets/c437bbc3-bc81-4e3c-86ae-1afa2b55d20c" />

### **After:**
<img width="984" height="895" alt="image" src="https://github.com/user-attachments/assets/a3147c0d-02d6-4c31-a960-4c6208215fbf" />

<img width="980" height="881" alt="image" src="https://github.com/user-attachments/assets/e513a9be-470d-4280-a088-e56252deb905" />

<img width="978" height="875" alt="image" src="https://github.com/user-attachments/assets/813063a2-b9c7-4599-97b0-24609eaae4a7" />
