### PR TITLE
Proposed adjustments to Item spawning / storage + reduce blood type card bloat

### DIFF
--- a/Neurotrauma/Xml/Items/Blood/BloodPacks.xml
+++ b/Neurotrauma/Xml/Items/Blood/BloodPacks.xml
@@ -3,8 +3,6 @@
 <Items>
     <Item name="" identifier="bloodpackoplus" nameidentifier="bloodpackoplus" variantof="antibloodloss2">
         <PreferredContainer primary="medcab" minamount="0" maxamount="0" notcampaign="true"/>
-        <PreferredContainer secondary="outpostmedcompartment,outpostmedcab" minamount="0" maxamount="0" spawnprobability="0"/>
-        <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="0" spawnprobability="0" />
         <PreferredContainer secondary="medcontainer"/>
 
         <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="194,325,64,64" origin="0.5,0.5"/>
@@ -29,8 +27,6 @@
 
     <Item name="" identifier="bloodpackaplus" nameidentifier="bloodpackaplus" variantof="antibloodloss2">
         <PreferredContainer primary="medcab" minamount="0" maxamount="0" notcampaign="true"/>
-        <PreferredContainer secondary="outpostmedcompartment,outpostmedcab" minamount="0" maxamount="0" spawnprobability="0"/>
-        <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="0" spawnprobability="0" />
         <PreferredContainer secondary="medcontainer"/>
 
         <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="260,260,64,64" origin="0.5,0.5"/>
@@ -43,7 +39,6 @@
     <Item name="" identifier="bloodpackbminus" nameidentifier="bloodpackbminus" variantof="antibloodloss2">
         <PreferredContainer primary="medcab" minamount="0" maxamount="0" notcampaign="true"/>
         <PreferredContainer secondary="outpostmedcompartment,outpostmedcab" minamount="0" maxamount="0" spawnprobability="0"/>
-        <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="0" spawnprobability="0" />
         <PreferredContainer secondary="medcontainer"/>
 
         <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="331,261,64,64" origin="0.5,0.5"/>
@@ -55,8 +50,6 @@
 
     <Item name="" identifier="bloodpackbplus" nameidentifier="bloodpackbplus" variantof="antibloodloss2">
         <PreferredContainer primary="medcab" minamount="0" maxamount="0" notcampaign="true"/>
-        <PreferredContainer secondary="outpostmedcompartment,outpostmedcab" minamount="0" maxamount="0" spawnprobability="0"/>
-        <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="0" spawnprobability="0" />
         <PreferredContainer secondary="medcontainer"/>
 
         <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="260,326,64,64" origin="0.5,0.5"/>
@@ -69,7 +62,6 @@
     <Item name="" identifier="bloodpackabminus" nameidentifier="bloodpackabminus" variantof="antibloodloss2">
         <PreferredContainer primary="medcab" minamount="0" maxamount="0" notcampaign="true"/>
         <PreferredContainer secondary="outpostmedcompartment,outpostmedcab" minamount="0" maxamount="0" spawnprobability="0"/>
-        <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="0" spawnprobability="0" />
         <PreferredContainer secondary="medcontainer"/>
 
         <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="396,263,64,64" origin="0.5,0.5"/>
@@ -81,8 +73,6 @@
 
     <Item name="" identifier="bloodpackabplus" nameidentifier="bloodpackabplus" variantof="antibloodloss2">
         <PreferredContainer primary="medcab" minamount="0" maxamount="0" notcampaign="true"/>
-        <PreferredContainer secondary="outpostmedcompartment,outpostmedcab" minamount="0" maxamount="0" spawnprobability="0"/>
-        <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="0" spawnprobability="0" />
         <PreferredContainer secondary="medcontainer"/>
 
         <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="193,260,64,64" origin="0.5,0.5"/>

--- a/Neurotrauma/Xml/Items/Blood/DonorCard.xml
+++ b/Neurotrauma/Xml/Items/Blood/DonorCard.xml
@@ -1,68 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Override>
-<Items>
+  <Items>
     <Item name="" identifier="ominuscard" category="Equipment" description="" Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate">
-        <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5"/>
-        <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16"/>
-        <Body width="16" height="12" density="20"/>
-        <Holdable slots="Any" msg="ItemMsgPickUpSelect"/>
-        <Deconstruct/>
+      <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5" />
+      <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16" />
+      <Body width="16" height="12" density="20" />
+      <Holdable slots="Any" msg="ItemMsgPickUpSelect" />
+      <Deconstruct />
     </Item>
 
-    <Item name="" identifier="opluscard" category="Equipment" description="" Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate">
-        <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5"/>
-        <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16"/>
-        <Body width="16" height="12" density="20"/>
-        <Holdable slots="Any" msg="ItemMsgPickUpSelect"/>
-        <Deconstruct/>
-    </Item>
-
-    <Item name="" identifier="aminuscard" category="Equipment" description="" Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate">
-        <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5"/>
-        <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16"/>
-        <Body width="16" height="12" density="20"/>
-        <Holdable slots="Any" msg="ItemMsgPickUpSelect"/>
-        <Deconstruct/>
-    </Item>
-
-    <Item name="" identifier="apluscard" category="Equipment" description="" Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate">
-        <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5"/>
-        <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16"/>
-        <Body width="16" height="12" density="20"/>
-        <Holdable slots="Any" msg="ItemMsgPickUpSelect"/>
-        <Deconstruct/>
-    </Item>
-
-    <Item name="" identifier="bminuscard" category="Equipment" description="" Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate">
-        <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5"/>
-        <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16"/>
-        <Body width="16" height="12" density="20"/>
-        <Holdable slots="Any" msg="ItemMsgPickUpSelect"/>
-        <Deconstruct/>
-    </Item>
-
-    <Item name="" identifier="bpluscard" category="Equipment" description="" Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate">
-        <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5"/>
-        <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16"/>
-        <Body width="16" height="12" density="20"/>
-        <Holdable slots="Any" msg="ItemMsgPickUpSelect"/>
-        <Deconstruct/>
-    </Item>
-
-    <Item name="" identifier="abminuscard" category="Equipment" description="" Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate">
-        <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5"/>
-        <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16"/>
-        <Body width="16" height="12" density="20"/>
-        <Holdable slots="Any" msg="ItemMsgPickUpSelect"/>
-        <Deconstruct/>
-    </Item>
-
-    <Item name="" identifier="abpluscard" category="Equipment" description="" Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate">
-        <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5"/>
-        <Sprite texture="Content/Items/idcard.png" depth="0.8" sourcerect="0,0,16,16"/>
-        <Body width="16" height="12" density="20"/>
-        <Holdable slots="Any" msg="ItemMsgPickUpSelect"/>
-        <Deconstruct/>
-    </Item>
-</Items>
+    <Item name="" identifier="opluscard" variantof="ominuscard" category="Equipment" description="" Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate" />
+    <Item name="" identifier="aminuscard" variantof="ominuscard" category="Equipment" description="" Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate" />
+    <Item name="" identifier="apluscard" variantof="ominuscard" category="Equipment" description="" Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate" />
+    <Item name="" identifier="bminuscard" variantof="ominuscard" category="Equipment" description="" Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate" />
+    <Item name="" identifier="bpluscard" variantof="ominuscard" category="Equipment" description="" Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate" />
+    <Item name="" identifier="abminuscard" variantof="ominuscard" category="Equipment" description="" Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate" />
+    <Item name="" identifier="abpluscard" variantof="ominuscard" category="Equipment" description="" Tags="smallitem,donorCard" cargocontaineridentifier="metalcrate" />
+  </Items>
 </Override>

--- a/Neurotrauma/Xml/Items/Blood/Gear.xml
+++ b/Neurotrauma/Xml/Items/Blood/Gear.xml
@@ -4,7 +4,6 @@
     <!-- Blood type analyzer + collection cartridge -->
     <Item name="" description="" identifier="bloodanalyzer" category="Equipment" cargocontaineridentifier="metalcrate" tags="smallitem,medical" useinhealthinterface="true" impactsoundtag="impact_metal_light" scale="0.4">
         <PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="1"/>
-        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="1" spawnprobability="0.25"/>
 
         <Price baseprice="250">
             <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
@@ -49,7 +48,7 @@
     </Item>
 
     <Item name="" identifier="bloodcollector" category="Equipment" description="" cargocontaineridentifier="mediccrate" Tags="smallitem,Material,vial,medical,bloodscannercard" useinhealthinterface="true" scale="0.170" impactsoundtag="impact_metal_light" maxstacksize="32" maxstacksizecharacterinventory="8">
-        <!--<PreferredContainer primary="medcab" minamount="1" maxamount="8" spawnprobability="1"/>-->
+        <PreferredContainer primary="medcab" minamount="0" maxamount="0" spawnprobability="0"/>
 
         <Price baseprice="5">
             <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="8"/>

--- a/Neurotrauma/Xml/Items/Chemicals.xml
+++ b/Neurotrauma/Xml/Items/Chemicals.xml
@@ -4,9 +4,8 @@
     <!-- Ringer's solution / a better version of saline -->
     <Item name="" identifier="ringerssolution" category="Medical" maxstacksize="32" maxstacksizecharacterinventory="8" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,petfood1,petfood2,petfood3" useinhealthinterface="true" description="" scale="0.35" impactsoundtag="impact_soft">
         <Upgrade gameversion="0.10.0.0" scale="0.5"/>
-        <!--<PreferredContainer primary="medcab" minamount="6" maxamount="8"/>-->
-        <!--<PreferredContainer primary="supplycab" minamount="3" maxamount="4" spawnprobability="0.5"/>-->
-        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="4" spawnprobability="0.5"/>
+        <PreferredContainer primary="medcab" minamount="0" maxamount="0"/>
+        <PreferredContainer primary="abandonedmedcab" minamount="0" maxamount="4" spawnprobability="0.25"/>
 
         <Price baseprice="50">
             <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="15"/>
@@ -52,7 +51,7 @@
     <!-- Mannitol / heals cerebral hypoxia / only if blood pressure and oxygen presence has been restored -->
     <Item name="" identifier="mannitol" category="Medical" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,syringe" description="" useinhealthinterface="true" scale="0.275" impactsoundtag="impact_metal_light" maxstacksize="32" maxstacksizecharacterinventory="8">
         <PreferredContainer primary="medcab" spawnprobability="0.2"/>
-        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.25"/>
+        <PreferredContainer primary="abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.10"/>
         <PreferredContainer primary="outposttrashcan" minamount="0" maxamount="2" spawnprobability="0.01"/>
 
         <Price baseprice="300" soldbydefault="false">
@@ -78,7 +77,7 @@
         <Body width="35" height="70" density="20"/>
 
         <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect" HitOnlyCharacters="true">
-            <RequiredSkill identifier="medical" level="60"></RequiredSkill>
+            <RequiredSkill identifier="medical" level="60"/>
             <StatusEffect type="OnSuccess" target="This" Condition="-100.0" setvalue="true"/>
             <StatusEffect type="OnFailure" target="This" Condition="-100.0" setvalue="true"/>
             <StatusEffect statuseffecttags="medical" multiplyafflictionsbymaxvitality="true" type="OnSuccess" target="UseTarget" duration="10">
@@ -115,8 +114,8 @@
 
     <!-- Azathioprine / immunosuppressant -->
     <Item name="" identifier="immunosuppressant" category="Medical" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,surgerytool" description="" useinhealthinterface="true" scale="0.3" impactsoundtag="impact_metal_light" maxstacksize="32" maxstacksizecharacterinventory="8">
-        <!--<PreferredContainer primary="toxcontainer" spawnprobability="0.2"/>-->
-        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.1"/>
+        <PreferredContainer primary="medcab" spawnprobability="0"/>
+        <PreferredContainer primary="abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.05"/>
         <PreferredContainer primary="outposttrashcan" minamount="0" maxamount="2" spawnprobability="0.01"/>
 
         <Price baseprice="100" soldbydefault="false">
@@ -162,8 +161,8 @@
 
     <!-- Thiamine / organ fixer -->
     <Item name="" identifier="thiamine" category="Medical" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical" description="" useinhealthinterface="true" scale="0.2" impactsoundtag="impact_metal_light" maxstacksize="32" maxstacksizecharacterinventory="8">
-        <!--<PreferredContainer primary="medcab" spawnprobability="0.2"/>-->
-        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.1"/>
+        <PreferredContainer primary="medcab" spawnprobability="0"/>
+        <PreferredContainer primary="abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.05"/>
         <PreferredContainer primary="outposttrashcan" minamount="0" maxamount="2" spawnprobability="0.01"/>
 
         <Price baseprice="100" soldbydefault="false">
@@ -207,7 +206,7 @@
     <!-- Streptokinase / heals heart attack -->
     <Item name="" identifier="streptokinase" category="Medical" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,syringe" description="" useinhealthinterface="true" scale="0.275" impactsoundtag="impact_metal_light" maxstacksize="32" maxstacksizecharacterinventory="8">
         <PreferredContainer primary="medcab" spawnprobability="0.2"/>
-        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.25"/>
+        <PreferredContainer primary="abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.10"/>
         <PreferredContainer primary="outposttrashcan" minamount="0" maxamount="2" spawnprobability="0.01"/>
 
         <Price baseprice="100" soldbydefault="false">
@@ -252,8 +251,7 @@
     <!-- Maybe it's worth moving to Consumables.xml. By: TheManyFacedDemon -->
     <Item name="" identifier="ointment" category="Medical" Tags="smallitem,medical" maxstacksize="32" maxstacksizecharacterinventory="8" useinhealthinterface="true" cargocontaineridentifier="mediccrate" scale="0.265" impactsoundtag="impact_soft">
         <PreferredContainer primary="medcab" minamount="16" maxamount="24" spawnprobability="1"/>
-        <!--<PreferredContainer primary="supplycab" minamount="1" maxamount="2" spawnprobability="0.1"/>-->
-        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="3" spawnprobability="0.12"/>
+        <PreferredContainer primary="abandonedmedcab" minamount="0" maxamount="3" spawnprobability="0.10"/>
         <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="5" spawnprobability="0.25"/>
 
         <Price baseprice="40">
@@ -292,7 +290,7 @@
 
     <!-- Propofol / anesthetic -->
     <Item name="" identifier="propofol" category="Medical" maxstacksize="4" maxstacksizecharacterinventory="2" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,syringe" description="" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_metal_light">
-        <PreferredContainer primary="toxcab,abandonedtoxcab" secondary="toxcontainer" mincount="0" maxcount="1" spawnprobability="0.0125"/>
+        <PreferredContainer primary="toxcab,abandonedtoxcab" secondary="toxcontainer" mincount="0" maxcount="1" spawnprobability="0.01"/>
 
         <Price baseprice="200" soldbydefault="false">
             <Price storeidentifier="merchantmedical" sold="true" multiplier="8" minavailable="1"/>

--- a/Neurotrauma/Xml/Items/Consumables.xml
+++ b/Neurotrauma/Xml/Items/Consumables.xml
@@ -3,7 +3,7 @@
 <Items>
     <Item name="" identifier="suture" category="Medical" maxstacksize="32" maxstacksizecharacterinventory="16" cargocontaineridentifier="mediccrate" Tags="smallitem,medical,surgery,surgerytool" description="" useinhealthinterface="True" scale="0.250">
         <PreferredContainer primary="medcab" minamount="48" maxamount="64" spawnprobability="1"/>
-        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="2" maxamount="6" spawnprobability="0.5"/>
+        <PreferredContainer primary="abandonedmedcab" minamount="2" maxamount="6" spawnprobability="0.5"/>
         <PreferredContainer primary="outpostmedcompartment" minamount="10" maxamount="16" spawnprobability="0.25"/>
 
         <Fabricate suitablefabricators="medicalfabricator" amount="16" requiredtime="10">
@@ -78,7 +78,7 @@
 
     <Item name="" identifier="gypsum" category="Medical" Tags="smallitem,medical" maxstacksize="16" maxstacksizecharacterinventory="4" useinhealthinterface="true" cargocontaineridentifier="mediccrate" description="" scale="0.3" impactsoundtag="impact_soft">
         <PreferredContainer primary="medcab" minamount="12" maxamount="16" spawnprobability="1"/>
-        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="1" spawnprobability="0.5"/>
+        <PreferredContainer primary="abandonedmedcab" minamount="0" maxamount="1" spawnprobability="0.5"/>
         <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="1" spawnprobability="0.125"/>
 
         <Price baseprice="40">

--- a/Neurotrauma/Xml/Items/Containers.xml
+++ b/Neurotrauma/Xml/Items/Containers.xml
@@ -29,7 +29,6 @@
     
     <Item name="" identifier="organtoolbox" category="Equipment" tags="mediumitem,mobilecontainer,tool,refrigerated,toolbox" cargocontaineridentifier="" showcontentsintooltip="true" Scale="0.5" fireproof="true" impactsoundtag="impact_metal_heavy" RequireAimToUse="True" description="">
         <PreferredContainer primary="medcab" minamount="2" maxamount="2"/>
-        <PreferredContainer secondary="wreckstoragecab" spawnprobability="0.05"/>
         <PreferredContainer secondary="locker"/>
         
         <Price baseprice="100">
@@ -80,7 +79,6 @@
    
     <Item name="" identifier="medtoolbox" category="Equipment" tags="mediumitem,mobilecontainer,tool,toolbox" cargocontaineridentifier="" showcontentsintooltip="true" Scale="0.5" fireproof="true" impactsoundtag="impact_metal_heavy" RequireAimToUse="True" description="">
         <PreferredContainer primary="medcab"/>
-        <PreferredContainer secondary="wreckstoragecab" spawnprobability="0.05"/>
         <PreferredContainer secondary="locker"/>
         
         <Deconstruct time="10">
@@ -302,8 +300,8 @@
         
         <Deconstruct time="10"/>
 
-        <!--<PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="0.75" />-->
-        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="1" spawnprobability="0.15" />
+        <PreferredContainer primary="medcab" minamount="0" maxamount="0" spawnprobability="0" />
+        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="1" spawnprobability="0.10" />
         <InventoryIcon texture="%ModDir%\Images\Suits\blackbag.png" sourcerect="0,0,67,45" origin="0.5,0.5" />
         <Sprite texture="%ModDir%\Images\Suits\blackbag.png" sourcerect="0,0,67,45" depth="0.55" origin="0.5,0.5" />
         <Body radius="20" width="67" density="15" />
@@ -381,7 +379,7 @@
         </Deconstruct>
        
         <PreferredContainer primary="medcab" minamount="0" maxamount="1" spawnprobability="0.5" />
-        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="1" spawnprobability="0.15" />
+        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="1" spawnprobability="0.1" />
         <InventoryIcon texture="%ModDir%\Images\Suits\bag.png" sourcerect="0,0,67,46" origin="0.5,0.5" />
         <Sprite texture="%ModDir%\Images\Suits\bag.png" sourcerect="0,0,68,46" depth="0.55" origin="0.5,0.5" />
         <Body radius="20" width="67" density="15" />

--- a/Neurotrauma/Xml/Items/FirstAID.xml
+++ b/Neurotrauma/Xml/Items/FirstAID.xml
@@ -38,8 +38,8 @@
 
     <!-- Needle / prevents pneuomothorax from worsening -->
     <Item name="" identifier="needle" category="Medical" cargocontaineridentifier="mediccrate" Tags="smallitem,medical,syringe,surgerytool" description="" useinhealthinterface="true" scale="0.2" impactsoundtag="impact_metal_light" maxstacksize="4">
-        <!--<PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="1"/>-->
-        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="1" spawnprobability="0.5"/>
+        <PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="1"/>
+        <PreferredContainer primary="abandonedmedcab" minamount="0" maxamount="1" spawnprobability="0.5"/>
         <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="1" spawnprobability="0.25"/>
 
         <Price baseprice="80" soldbydefault="false">
@@ -86,7 +86,7 @@
     <Item name="" identifier="gelipack" category="Medical" maxstacksize="8" maxstacksizecharacterinventory="1" cargocontaineridentifier="organcrate" Tags="smallitem,chem,medical,canexpire" useinhealthinterface="true" description="" scale="0.275" impactsoundtag="impact_soft">
         <Upgrade gameversion="0.10.0.0" scale="0.5"/>
         <PreferredContainer primary="medcab" minamount="2" maxamount="3"/>
-        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.35"/>
+        <PreferredContainer primary="abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.35"/>
         <PreferredContainer secondary="outpostmedcab" amount="1" spawnprobability="0.5" />
         <PreferredContainer secondary="outpostmedcompartment" amount="1" spawnprobability="0.2" />
 

--- a/Neurotrauma/Xml/Items/Gear/Defibrillators.xml
+++ b/Neurotrauma/Xml/Items/Gear/Defibrillators.xml
@@ -2,8 +2,7 @@
 <Override>
 <Items>
     <Item name="" identifier="defibrillator" category="Equipment" cargocontaineridentifier="mediccrate" Tags="smallitem,medical" description="" useinhealthinterface="True" scale="0.3">
-        <!--<PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="1"/>-->
-        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="1" spawnprobability="0.3"/>
+        <PreferredContainer primary="medcab" minamount="0" maxamount="0" spawnprobability="0"/>
 
         <Fabricate suitablefabricators="fabricator" requiredtime="10">
             <RequiredSkill identifier="electrical" level="40"/>
@@ -45,7 +44,6 @@
 
     <Item name="" identifier="aed" category="Equipment" cargocontaineridentifier="mediccrate" Tags="smallitem,medical" description="" useinhealthinterface="True" scale="0.3">
         <PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="1"/>
-        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="1" spawnprobability="0.1"/>
 
         <Fabricate suitablefabricators="fabricator" requiredtime="40">
             <RequiredSkill identifier="electrical" level="50"/>

--- a/Neurotrauma/Xml/Items/Gear/Items.xml
+++ b/Neurotrauma/Xml/Items/Gear/Items.xml
@@ -2,8 +2,7 @@
 <Override>
 <Items>
     <Item name="" identifier="bvm" category="Equipment" cargocontaineridentifier="mediccrate" Tags="smallitem,medical" description="" useinhealthinterface="True" scale="0.370">
-        <!--<PreferredContainer primary="medcab" minamount="1" maxamount="1" spawnprobability="1"/>-->
-        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="1" spawnprobability="0.3"/>
+        <PreferredContainer primary="medcab" minamount="0" maxamount="0" spawnprobability="0"/>
 
         <Fabricate suitablefabricators="fabricator" requiredtime="10">
             <RequiredSkill identifier="medical" level="30"/>
@@ -105,7 +104,6 @@
     <Item name="" identifier="autocpr" category="Equipment" useinhealthinterface="True" tags="smallitem,clothing,medical" scale="0.40" cargocontaineridentifier="metalcrate" description="" impactsoundtag="impact_soft">
         <Upgrade gameversion="0.9.3.0" scale="0.40"/>
         <PreferredContainer primary="medcab" minamount="2" maxamount="2" spawnprobability="1"/>
-        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="1" spawnprobability="0.25"/>
 
         <Price baseprice="300" soldbydefault="false">
             <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9"/>

--- a/Neurotrauma/Xml/Items/Override.xml
+++ b/Neurotrauma/Xml/Items/Override.xml
@@ -198,8 +198,8 @@
         <Item name="" identifier="antibloodloss1" category="Medical" maxstacksize="32" maxstacksizecharacterinventory="8" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,petfood1,petfood2,petfood3" useinhealthinterface="true" description="" scale="0.5" impactsoundtag="impact_soft">
             <Upgrade gameversion="0.10.0.0" scale="0.5"/>
             <PreferredContainer secondary="wrecksupplycab,beaconsupplycab" amount="1" spawnprobability="0.1" />
-            <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="3" spawnprobability="0.5" />
-            <!--<PreferredContainer primary="medcab" secondary="medcontainer"/>-->
+            <PreferredContainer secondary="abandonedmedcab" minamount="1" maxamount="3" spawnprobability="0.5" />
+            <PreferredContainer primary="medcab" secondary="medcontainer"/>
 
             <Price baseprice="50" minavailable="12">
                 <Price storeidentifier="merchantoutpost"/>
@@ -243,10 +243,10 @@
 
         <Item name="" identifier="antibloodloss2" nameidentifier="bloodpackominus" category="Medical" maxstacksize="32" maxstacksizecharacterinventory="8" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,petfood1,bloodbag" useinhealthinterface="true" description="" scale="0.5" impactsoundtag="impact_soft">
             <Upgrade gameversion="0.10.0.0" scale="0.5" />
-            <!--<PreferredContainer primary="medcab" minamount="2" maxamount="3" notcampaign="true"/>-->
+            <PreferredContainer primary="medcab" minamount="0" maxamount="0"/>
             <PreferredContainer secondary="outpostmedcab" minamount="1" maxamount="2" spawnprobability="0.2"/>
             <PreferredContainer secondary="outpostmedcompartment" amount="1" spawnprobability="0.05"/>
-            <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="2" spawnprobability="0.2" />
+            <PreferredContainer secondary="abandonedmedcab" minamount="1" maxamount="2" spawnprobability="0.2" />
             <PreferredContainer secondary="medcontainer"/>
             <PreferredContainer secondary="researchcontainer" spawnprobability="0.02"/>
             <Price baseprice="240">
@@ -273,8 +273,8 @@
         <Item name="" identifier="antibleeding1" aliases="Bandage" category="Medical" Tags="smallitem,medical" maxstacksize="32" maxstacksizecharacterinventory="8" useinhealthinterface="true" cargocontaineridentifier="mediccrate" description="" scale="0.5" impactsoundtag="impact_soft" RequireAimToUse="True">
             <Upgrade gameversion="0.10.0.0" scale="0.5" />
             <PreferredContainer secondary="supplycab" minamount="1" maxamount="2" spawnprobability="0.5" notcampaign="true"/>
-            <PreferredContainer secondary="wrecksupplycab,beaconsupplycab" amount="1" spawnprobability="0.3" />
-            <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="2" spawnprobability="0.8" />
+            <PreferredContainer secondary="beaconsupplycab" amount="1" spawnprobability="0.3" />
+            <PreferredContainer secondary="abandonedmedcab" minamount="1" maxamount="2" spawnprobability="0.8" />
             <PreferredContainer secondary="outpostmedcab" minamount="1" maxamount="3" spawnprobability="0.5" />
             <PreferredContainer secondary="outpostmedcompartment" amount="1" spawnprobability="0.2" />
             <PreferredContainer secondary="researchcontainer" spawnprobability="0.02"/>
@@ -312,7 +312,7 @@
         <Item name="" identifier="antibleeding2" category="Medical" Tags="smallitem,medical" maxstacksize="32" maxstacksizecharacterinventory="8" cargocontaineridentifier="mediccrate" description="" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_soft" RequireAimToUse="True">
             <Upgrade gameversion="0.10.0.0" scale="0.5" />
             <PreferredContainer primary="medcab" secondary="medcontainer"/>
-            <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="1" maxamount="2" spawnprobability="0.4" />
+            <PreferredContainer secondary="abandonedmedcab" minamount="1" maxamount="2" spawnprobability="0.4" />
             <PreferredContainer secondary="outpostmedcab" minamount="1" maxamount="3" spawnprobability="0.3" />
             <PreferredContainer secondary="outpostmedcompartment" amount="1" spawnprobability="0.1" />
             <PreferredContainer secondary="researchcontainer" spawnprobability="0.02"/>
@@ -564,8 +564,8 @@
         <!-- Opium, Morphine, Fentanyl, Naloxone -->
         <Item name="" identifier="opium" category="Medical" maxstacksize="32" maxstacksizecharacterinventory="8" Tags="smallitem,chem,medical" description="" cargocontaineridentifier="mediccrate" scale="0.5" useinhealthinterface="true" RequireAimToUse="True">
             <Upgrade gameversion="0.10.0.0" scale="0.5"/>
+            <PreferredContainer primary="medfabcab" secondary="medcontainer"/>
             <PreferredContainer secondary="abandonedmedcab,wreckmedcab" minamount="1" maxamount="2" spawnprobability="0.5" />
-            <!--<PreferredContainer primary="medfabcab" secondary="medcontainer"/>-->
             <PreferredContainer secondary="outposttrashcan" amount="1" spawnprobability="0.2" />
 
             <Price baseprice="40">
@@ -715,7 +715,7 @@
 
         <Item name="" identifier="antidama2" category="Medical" maxstacksize="32" maxstacksizecharacterinventory="8" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,syringe" description="" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_metal_light" RequireAimToUse="True">
             <Upgrade gameversion="0.10.0.0" scale="0.5" />
-            <!--<PreferredContainer primary="medcab" secondary="medcontainer"/>-->
+            <PreferredContainer primary="medcab"  minamount="0" maxamount="0" />
             <PreferredContainer secondary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="1" spawnprobability="0.4" />
             <PreferredContainer secondary="outpostmedcab" minamount="1" maxamount="3" spawnprobability="0.3" />
             <PreferredContainer secondary="outpostmedcompartment" amount="1" spawnprobability="0.1" />
@@ -803,10 +803,10 @@
 
         <Item name="" identifier="antinarc" category="Medical" maxstacksize="32" maxstacksizecharacterinventory="8" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,syringe" useinhealthinterface="true" description="" scale="0.5" impactsoundtag="impact_metal_light" RequireAimToUse="True">
             <Upgrade gameversion="0.10.0.0" scale="0.5" />
+            <PreferredContainer primary="medcab"  minamount="0" maxamount="0" />
             <PreferredContainer secondary="wreckmedcab,abandonedmedcab" amount="1" spawnprobability="0.2" />
             <PreferredContainer secondary="outpostmedcab" amount="1" spawnprobability="0.5" />
             <PreferredContainer secondary="outpostmedcompartment" amount="1" spawnprobability="0.2" />
-            <!--<PreferredContainer primary="medcab" secondary="medcontainer"/>-->
 
             <Price baseprice="100" minavailable="2">
                 <Price storeidentifier="merchantmedical" multiplier="0.9"/>
@@ -937,8 +937,9 @@
 
         <Item name="" identifier="adrenaline" category="Medical,Material" maxstacksize="32" maxstacksizecharacterinventory="8" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,syringe" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_metal_light" RequireAimToUse="True">
             <Upgrade gameversion="0.10.0.0" scale="0.5" />
-            <!--<PreferredContainer primary="medfabcab" secondary="medcontainer"/>-->
+            <PreferredContainer primary="medcab"  minamount="0" maxamount="0" />
             <PreferredContainer secondary="abandonedmedcab,wreckmedcab" minamount="1" maxamount="2" spawnprobability="0.5" />
+            
             <Price baseprice="60">
                 <Price storeidentifier="merchantoutpost" sold="false" multiplier="1.25" />
                 <Price storeidentifier="merchantcity" sold="false" multiplier="1.25" />
@@ -1055,6 +1056,7 @@
         <!-- liquid oxygenite -->
         <Item name="" identifier="liquidoxygenite" category="Medical" maxstacksize="32" maxstacksizecharacterinventory="8" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,syringe" impacttolerance="8" description="" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_metal_light" RequireAimToUse="True">
             <Upgrade gameversion="0.10.0.0" scale="0.5" />
+            <PreferredContainer primary="medcab"  minamount="0" maxamount="0" />
 
             <Price baseprice="80">
                 <Price storeidentifier="merchantoutpost" sold="false" />
@@ -1485,10 +1487,10 @@
         <!-- Haloperidol -->
         <Item name="" identifier="antipsychosis" category="Medical" maxstacksize="32" maxstacksizecharacterinventory="8" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical,syringe" useinhealthinterface="true" description="" scale="0.5" impactsoundtag="impact_metal_light" RequireAimToUse="True">
             <Upgrade gameversion="0.10.0.0" scale="0.5" />
+            <PreferredContainer primary="medcab" secondary="medcontainer"/>
             <PreferredContainer secondary="wreckmedcab,abandonedmedcab" amount="1" spawnprobability="0.2" />
             <PreferredContainer secondary="outpostmedcab" amount="1" spawnprobability="0.2" />
             <PreferredContainer secondary="outpostmedcompartment" amount="1" spawnprobability="0.06" />
-            <!--<PreferredContainer primary="medcab" secondary="medcontainer"/>-->
 
             <Price baseprice="130" minavailable="4">
                 <Price storeidentifier="merchantoutpost"/>
@@ -1711,6 +1713,7 @@
         <!-- Nitroglycerin | change: now acts as blood pressure reducing medicine.-->
         <Item name="" identifier="nitroglycerin" category="Medical,Material,Weapon" maxstacksize="32" maxstacksizecharacterinventory="8" description="" spritecolor="1.0,1.0,1.0,1.0" containercolor="1.0,1.0,1.0,1.0" cargocontaineridentifier="explosivecrate" Tags="smallitem,chem,medical" impacttolerance="6" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_metal_light">
             <PreferredContainer primary="secarmcab" secondary="armcab"/>
+            <PreferredContainer secondary="medcab"/>
             <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab" amount="1" spawnprobability="0.01"/>
 
             <Price baseprice="150">

--- a/Neurotrauma/Xml/Items/Surgery/Implants.xml
+++ b/Neurotrauma/Xml/Items/Surgery/Implants.xml
@@ -4,7 +4,7 @@
     <Item name="" identifier="osteosynthesisimplants" category="Medical" cargocontaineridentifier="mediccrate" Tags="smallitem,medical,surgery,surgerytool" description="" useinhealthinterface="True" scale="0.4">
         <PreferredContainer primary="medcab"/>
         <PreferredContainer secondary="locker"/>
-        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.15" />
+        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.05" />
         <Price baseprice="200" soldbydefault="false">
             <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
         </Price>
@@ -39,7 +39,7 @@
     <Item name="" identifier="spinalimplant" description="" category="Medical" scale="0.3" useinhealthinterface="True" cargocontaineridentifier="mediccrate" Tags="smallitem,medical,surgery,surgerytool">
         <PreferredContainer primary="medcab"/>
         <PreferredContainer secondary="locker"/>
-        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.15" />
+        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.05" />
 
         <Price baseprice="200" soldbydefault="false">
             <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>


### PR DESCRIPTION
Adjusts item 'preferredcontainers' and for some their spawn chance to sync their behaviour to other medicines, and nuke spawns in wrecks for most items; as well as a minor change to Blood Type Cards. Additionally, removed preferredcontainers that were empty and were not on the player submarine (so they don't impact AI sorting).

Reasoning at the bottom. Change as needed.

### Blood Cards:
- By using variants, you can reduce the DonorCard.xml by 40+ lines and make future changes easier. No impact on functionality.

## Changes per file / category:

###  Blood:
1. Empty Donor Cards: Added to Medical Cabinet.
2. Hematology Analyzer: Removed from Wreck and Abandoned Cabinets.
3. Blood Packs: Removed from Outpost, Wreck and Abandoned Cabinets.
 
### Gear:
1. Manual Defibrillator: Removed from Wreck and Abandoned Cabinets. Added to Medical Cabinet.
2. Automated External Defibrillator: Removed from Wreck and Abandoned Cabinets. 
3. BVM: Removed from Wreck and Abandoned Cabinets. Added to Medical Cabinet.
4. AutoPulse: Removed from Wreck and Abandoned Cabinets.

### Surgery:
1. Osteosynthesis Implants: Spawn rate decreased by 10% from 15% to 5%.
2. Spinal Cord Implants: Spawn rate decreased by 10% from 15% to 5%.

### Chemicals:
1. Ringers: Removed from Wrecks. Added to Medical Cabinet. Spawn rate decreased by 25% from 50% to 25% in Abandoned Cabinets.
2. Mannitol: Removed from Wrecks. Spawn rate decreased by 15% from 25% to 10% in Abandoned Cabinets.
3. Azathioprine: Removed from Wrecks. Added to Medical Cabinet. Spawn rate decreased by 5% from 10% to 5% in Abandoned Cabinets.
4. Thiamine: Removed from Wrecks. Added to Medical Cabinet. Spawn rate decreased by 5% from 10% to 5% in Abandoned Cabinets.
5. Streptokinase: Removed from Wrecks. Spawn rate decreased by 15% from 25% to 10% in Abandoned Cabinets.
6. Ointment: Removed from Wrecks. Spawn rate decreased by 2% from 12% to 10% in Abandoned Cabinets.
7. Propofol: Spawn rate decreased by 0.25% from 1.25% to 1% (vro.)

### Consumables:
1. Sutures: Removed from Wrecks.
2. Gypsum: Removed from Wrecks.

### Containers:
1. Refrigerated Container: Removed from Wrecks.
2. Medical Container: Removed from Wrecks.
3. Body Bags: Added to Medical Cabinet. Spawn rate decreased by 5% from 15% to 10% in Abandoned and Wrecked Cabinets.
4. Stasis Bags: Spawn rate decreased by 5% from 15% to 10% in Abandoned and Wrecked Cabinets.

### First Aid:
1. Needle: Removed from Wrecks. Added to Medical Cabinet.
2. Gel Coolant Pack: Removed from Wrecks.

### Overrides:
1. Saline: Removed from Wrecks. Added to Medical Cabinet.
2. 0- Blood Pack: Removed from Wrecks. Added to Medical Cabinet.
3. Bandage: Removed from Wrecks.
4. Plastiseal: Removed from Wrecks.
5. Opium: Added to Medical Cabinet.
6. Fentanyl: Added to Medical Cabinet.
7. Naloxone: Added to Medical Cabinet.
8. Adrenaline: Added to Medical Cabinet.
9. Liquid Oxygenite: Added to Medical Cabinet.
10. Haloperidol: Added to Medical Cabinet.
11. Nitroglycerin: Added to Medical Cabinet as Secondary Preferred.

## Reasoning:

- For all "Added to Medical Cabinet" entries, they have been given it as a preferred container **without** adding spawn parameters. This means AI crewmates who clean up items will stop deciding to put Naloxone in the Reactor Room Cabinet instead of the medbay cabinet right next to it. Should also make buying a submarine less of a headache as medical items now actually get put into the medbay instead of fucking everywhere else.

- For most "Removed from Wrecks" entries, these are supposed to be 'sterile' or otherwise clean medicines; a bandage that has been sitting in a fully overgrown medical cabinet submerged in water for a few in-game years should either not exist or instantly give you some kind of infection. The former being the easiest to make happen. 15 year old Gypsum powder soaked with water would make for an interesting plaster cast.

- Alternatively, they are Gear items like the BVM, Autopulse or Containers and were likewise removed since you'd think electronic equipment like that wouldn't survive down there - and generally you already have all you'd want. Likewise, containers are just empty boxes you'd have already made if you needed the space and 99% of the time are just deconstruction fodder. Interestingly enough, Surgical Containers already didn't spawn in wrecks; filled or empty.

- The few spawn rate decreases are items that either can survive wrecks (but are otherwise quite niche) or found in Abandoned Outposts and equally as niche. Personally, I think you should get anything you want to inject, rub unto or install into a crewmate either from your own fabricator or a store; not some decrepit bandit outpost or a mudraptor nest. Alternatively, they had a spawn rate that made no sense in my opinion and were made more in-line with others (why does ringers, the 'advanced saline', spawn more than saline..)