### PR TITLE
Nuke Nitroglycerin in favour of Nitroprusside

### DIFF
--- a/Neurotrauma/Xml/Items/Chemicals.xml
+++ b/Neurotrauma/Xml/Items/Chemicals.xml
@@ -490,5 +490,50 @@
 
         <SkillRequirementHint identifier="medical" level="10"/>
     </Item>
+
+    <!-- Sodium Nitroprussed / Blood Pressure reducer -->
+    <Item name="" identifier="pressuremeds" category="Medical" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical" description="" useinhealthinterface="true" scale="0.2" impactsoundtag="impact_metal_light" maxstacksize="32" maxstacksizecharacterinventory="8">
+        <PreferredContainer primary="medcab" spawnprobability="0.2"/>
+        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.1"/>
+        <PreferredContainer primary="outposttrashcan" minamount="0" maxamount="2" spawnprobability="0.01"/>
+
+        <Price baseprice="100" soldbydefault="false">
+            <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="2"/>
+        </Price>
+
+        <Fabricate suitablefabricators="medicalfabricator" requiredtime="20" amount="3">
+            <RequiredSkill identifier="medical" level="30"/>
+            <RequiredItem identifier="sodium"/>
+            <RequiredItem identifier="nitroglycerin"/>
+        </Fabricate>
+
+        <Deconstruct time="5"/>
+
+        <InventoryIcon texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="812,512,50,126" origin="0.5,0.5"/>
+        <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="812,512,50,126" depth="0.6" origin="0.5,0.5"/>
+        <Body width="35" height="70" density="20"/>
+
+        <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
+            <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
+            <RequiredSkill identifier="medical" level="10"/>
+            <StatusEffect statuseffecttags="medical" multiplyafflictionsbymaxvitality="true" type="OnSuccess" target="UseTarget" duration="10">
+                <Sound file="%ModDir%/Sound/pills1.ogg" range="500"/>
+                <Sound file="%ModDir%/Sound/pills2.ogg" range="500"/>
+                <Sound file="%ModDir%/Sound/pills3.ogg" range="500"/>
+                <Affliction identifier="afpressuredrug" amount="5"/>
+            </StatusEffect>
+            <StatusEffect statuseffecttags="medical" multiplyafflictionsbymaxvitality="true" type="OnFailure" target="UseTarget" duration="10">
+                <Sound file="%ModDir%/Sound/pills1.ogg" range="500"/>
+                <Sound file="%ModDir%/Sound/pills2.ogg" range="500"/>
+                <Sound file="%ModDir%/Sound/pills3.ogg" range="500"/>
+                <Affliction identifier="afpressuredrug" amount="3"/>
+            </StatusEffect>
+            <StatusEffect type="OnBroken" target="This">
+                <Remove/>
+            </StatusEffect>
+        </MeleeWeapon>
+
+        <SkillRequirementHint identifier="medical" level="10"/>
+    </Item>
 </Items>
 </Override>

--- a/Neurotrauma/Xml/Items/Override.xml
+++ b/Neurotrauma/Xml/Items/Override.xml
@@ -1709,65 +1709,6 @@
                 </StatusEffect>
             </Holdable>
         </Item>
-
-        <!-- Nitroglycerin | change: now acts as blood pressure reducing medicine.-->
-        <Item name="" identifier="nitroglycerin" category="Medical,Material,Weapon" maxstacksize="32" maxstacksizecharacterinventory="8" description="" spritecolor="1.0,1.0,1.0,1.0" containercolor="1.0,1.0,1.0,1.0" cargocontaineridentifier="explosivecrate" Tags="smallitem,chem,medical" impacttolerance="6" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_metal_light">
-            <PreferredContainer primary="secarmcab" secondary="armcab"/>
-            <PreferredContainer secondary="medcab"/>
-            <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab" amount="1" spawnprobability="0.01"/>
-
-            <Price baseprice="150">
-                <Price storeidentifier="merchantoutpost" sold="false" multiplier="1.4" />
-                <Price storeidentifier="merchantcity" multiplier="1.25" minavailable="2" sold="false"/>
-                <Price storeidentifier="merchantresearch" sold="false" multiplier="1.25" />
-                <Price storeidentifier="merchantmilitary" multiplier="0.9" minavailable="4" />
-                <Price storeidentifier="merchantmine" sold="false" />
-                <Price storeidentifier="merchantarmory" multiplier="0.9" minavailable="4" />
-                <Price storeidentifier="merchantmedical" multiplier="0.9" minavailable="4" />
-            </Price>
-
-            <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="640,768,64,64" origin="0.5,0.5" />
-            <Sprite texture="Content/Items/Weapons/weapons_new.png" sourcerect="110,414,31,62" depth="0.6" origin="0.5,0.5" />
-            <Body width="35" height="60" density="20" />
-
-
-            <Throwable characterusable="true" canbecombined="true" removeoncombined="true" slots="Any,RightHand,LeftHand" throwforce="3.5" aimpos="35,-10" msg="ItemMsgPickUpSelect">
-                <StatusEffect type="OnImpact" target="This" Condition="0.0" setvalue="true" />
-                <StatusEffect type="OnFire" target="This" Condition="-50.0" />
-                <StatusEffect type="OnBroken" target="This" Condition="-100.0">
-                    <sound file="Content/Items/Weapons/ExplosionMedium1.ogg" range="3000" />
-                    <sound file="Content/Items/Weapons/ExplosionMedium2.ogg" range="3000" />
-                    <sound file="Content/Items/Weapons/ExplosionMedium3.ogg" range="3000" />
-                    <Explosion range="300.0" ballastfloradamage="60" structuredamage="90" itemdamage="300" force="8" severlimbsprobability="0.3" debris="true" decal="explosion" decalsize="0.3">
-                        <Affliction identifier="explosiondamage" strength="75" dividebylimbcount="true"/>
-                        <Affliction identifier="burn" strength="10" probability="0.2" dividebylimbcount="false"/>
-                        <Affliction identifier="bleeding" strength="20" probability="0.05" dividebylimbcount="false"/>
-                        <Affliction identifier="stun" strength="5" />
-                    </Explosion>
-                    <Remove />
-                </StatusEffect>
-                <StatusEffect type="OnBroken" target="This">
-                    <sound file="Content/Items/Weapons/ExplosionDebris1.ogg" range="2000" />
-                    <sound file="Content/Items/Weapons/ExplosionDebris2.ogg" range="2000" />
-                </StatusEffect>
-                <RequiredSkill identifier="medical" level="35" />
-                <StatusEffect statuseffecttags="medical" multiplyafflictionsbymaxvitality="true" type="OnSuccess" target="UseTarget" disabledeltatime="true">
-                    <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-                    <Affliction identifier="afpressuredrug" amount="100" />
-                </StatusEffect>
-                <StatusEffect statuseffecttags="medical" type="OnSuccess" target="This" disabledeltatime="true">
-                    <Remove/>
-                </StatusEffect>
-                <StatusEffect statuseffecttags="medical" multiplyafflictionsbymaxvitality="true" type="OnFailure" target="UseTarget" disabledeltatime="true">
-                    <Sound file="Content/Items/Medical/Syringe.ogg" range="500" />
-                    <Affliction identifier="afpressuredrug" amount="50" />
-                </StatusEffect>
-                <StatusEffect statuseffecttags="medical" type="OnFailure" target="This" disabledeltatime="true">
-                    <Remove/>
-                </StatusEffect>
-            </Throwable>
-            <SkillRequirementHint identifier="medical" level="35" />
-        </Item>
         <Item name="" identifier="repairpack" category="Equipment" Tags="smallitem,tool,electricalrepairtool,mechanicalrepairtool,wrench,wrenchitem,screwdriver,multitool" cargocontaineridentifier="metalcrate" allowasextracargo="true" Scale="0.5" impactsoundtag="impact_metal_light" addedrepairspeedmultiplier="0.2" useinhealthinterface="True">
             <PreferredContainer primary="engcab"/>
             <Price baseprice="43" sold="false">


### PR DESCRIPTION
Resulting from the flood of comments of people who have an interesting playstyle that evidently requires carrying blood pressure reducers, a suggested change to make everyone happy.

### 'Issues' reported:
1. Nitroglycerin lasts too long
2. Nitroglycerin may explode if improperly handled

### Original reason for removal:
- Item was identical in effect to Nitroglycerin.

### Solution:
1. Remove the overriding of Nitroglycerin, removing it's blood-pressure lowering effects.
2. Bring back Nitroprusside, crafted identically to before (from Nitroglycerin) - now the sole blood-pressure reducer.

### Benefits:
1. People can be happy again and use their blood pressure reducing medication as much as they want.
2. There are no duplicate effects from medicinal items, constituting the original reason for removal.
3. Nitroprusside already had a lower active-time, so reinstating it as-is removes that problem too.
4. Not overriding a basegame item makes general compatibility better.