### PR TITLE
Add Spinal Cord Implant Sound

### DIFF
--- a/Neurotrauma/Xml/Items/Surgery/Implants.xml
+++ b/Neurotrauma/Xml/Items/Surgery/Implants.xml
@@ -60,7 +60,8 @@
 
         <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="5,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
             <StatusEffect type="OnUse" target="Limb, This" disabledeltatime="true" comparison="And">
-                <Conditional retractedskin="gt 50"/>
+              <Conditional retractedskin="gt 50" />
+              <Sound file="%ModDir%/Sound/drill.ogg" range="500" />
             </StatusEffect>
             <StatusEffect type="OnBroken" target="This">
                 <Remove/>


### PR DESCRIPTION
Currently, Osteosynthesis Implants make the 'drill' noise when installed.

Conversely, Spinal Cord Implants do not; they don't make any noise (as the only item with no audible feedback in Neurotrauma).

Even though Spinal Cord Implants don't require a drill for application (also unlike the Osteosynthesis ones), give it the Drill sound on application.