### PR TITLE
Possibility of Dynamic Item Utilization

### DIFF
--- a/Neurotrauma/Lua/Scripts/Client/configgui.lua
+++ b/Neurotrauma/Lua/Scripts/Client/configgui.lua
@@ -145,6 +145,10 @@ local function PopulateSettingsIntoUI(list, selectedExpansion)
 			-- Ungrouped float
 			if entry.type == "float" then
 				local minrange = (entry.range and entry.range[1]) or ""
+				-- This is fucking stupid. If the default value is the same as the minimum value of a scalar, it bugs and displays 0.
+				-- So, we set the minimum to 0.99 and just render it like it were 1
+				if minrange == 0.99 then minrange = 1 end
+
 				local maxrange = (entry.range and entry.range[2]) or ""
 
 				local rect = GUI.RectTransform(Vector2(1, 0.04), list.Content.RectTransform)
@@ -289,6 +293,8 @@ local function PopulateSettingsIntoUI(list, selectedExpansion)
 					GUI.LayoutGroup(GUI.RectTransform(Vector2(resetcellwidth, 0.59), row.RectTransform), false)
 
 				local minrange = entry.range and entry.range[1] or ""
+				if minrange == 0.99 then minrange = 1 end
+
 				local maxrange = entry.range and entry.range[2] or ""
 
 				local tb_EntryInformation = GUI.TextBlock(

--- a/Neurotrauma/Lua/Scripts/Client/dynamicitems.lua
+++ b/Neurotrauma/Lua/Scripts/Client/dynamicitems.lua
@@ -1,0 +1,114 @@
+local _Int32 = LuaUserData.RegisterType("System.Int32")
+
+-- Stack specific items together; if you want only the left leg to be cheaper than a right one go fuck yourself
+local ItemVariants = {
+	antibloodloss2 = "NT_ItemPrice_bloodpacks",
+	bloodpackoplus = "NT_ItemPrice_bloodpacks",
+	bloodpackaminus = "NT_ItemPrice_bloodpacks",
+	bloodpackaplus = "NT_ItemPrice_bloodpacks",
+	bloodpackbminus = "NT_ItemPrice_bloodpacks",
+	bloodpackbplus = "NT_ItemPrice_bloodpacks",
+	bloodpackabminus = "NT_ItemPrice_bloodpacks",
+	bloodpackabplus = "NT_ItemPrice_bloodpacks",
+	rarm = "NT_ItemPrice_arms",
+	larm = "NT_ItemPrice_arms",
+	rleg = "NT_ItemPrice_legs",
+	lleg = "NT_ItemPrice_legs",
+	rarmp = "NT_ItemPrice_bionicarms",
+	larmp = "NT_ItemPrice_bionicarms",
+	rlegp = "NT_ItemPrice_bioniclegs",
+	llegp = "NT_ItemPrice_bioniclegs",
+}
+
+-- Fetch config multipliers
+local function GetItemMultiplier(identifier)
+	if identifier == nil then return 1.0 end
+
+	-- Add grouping so blood bags don't fucking kill me
+	local configKey = ItemVariants[identifier] or ("NT_ItemPrice_" .. identifier)
+
+	if NTConfig.Entries[configKey] == nil then return 1.0 end
+
+	local value = NTConfig.Get(configKey, 1.0)
+	return tonumber(value) or 1.0
+end
+
+-- PRICE CHANGING
+-- Hook into the price-determining function and add a multiplier
+Hook.Patch("Barotrauma.Location+StoreInfo", "GetAdjustedItemBuyPrice", function(instance, ptable)
+	local item = ptable["item"]
+	if item == nil or item.Identifier == nil then return end
+
+	local id = item.Identifier.Value
+	local mult = GetItemMultiplier(id)
+
+	-- Don't do extra math if the item value is unchanged
+	if mult == 1.0 then return end
+
+	-- Get the 'actual price' after the game is done with it's calculations
+	local base = ptable.OriginalReturnValue
+	if base == nil then return end
+
+	-- Apply config-determined multiplier
+	local result = math.floor(base * mult + 0.5)
+
+	ptable.ReturnValue = LuaUserData.CreateUserDataFromDescriptor(result, _Int32)
+end, Hook.HookMethodType.After)
+
+-- FABRICATOR CHANGES
+-- You cannot fabricate the item; this is accomplished by taking the Filter that gets made whenever you open a fabricator, and hiding the specific item IDs we want to hide.
+local fabricatorType = LuaUserData.RegisterType("Barotrauma.Items.Components.Fabricator")
+LuaUserData.MakeFieldAccessible(fabricatorType, "itemList")
+Hook.Patch("Barotrauma.Items.Components.Fabricator", "FilterEntities", function(instance, ptable)
+	Timer.Wait(function()
+		local blockedItems = HF.DynamicUnavailableItems()
+
+		for child in instance.itemList.Content.Children do
+			local recipe = child.UserData
+
+			if recipe and LuaUserData.IsTargetType(recipe, "Barotrauma.FabricationRecipe") then
+				local id = recipe.TargetItem.Identifier.Value
+
+				if blockedItems[id] then child.Visible = false end
+			end
+		end
+	end, 1)
+end, Hook.HookMethodType.After)
+
+-- STORE CHANGES
+-- You cannot buy the item; we simply hook into store availability and hide the item.
+-- Ensure the items CANNOT be specials.
+local storeType = LuaUserData.RegisterType("Barotrauma.Store")
+LuaUserData.MakeFieldAccessible(storeType, "storeBuyList")
+LuaUserData.MakeFieldAccessible(storeType, "storeDailySpecialsGroup")
+
+Hook.Patch("Barotrauma.Store", "FilterStoreItems", {
+	"Barotrauma.MapEntityCategory",
+	"System.String",
+}, function(instance, ptable)
+	Timer.Wait(function()
+		-- Fetch items to hide
+		local blockedItems = HF.DynamicUnavailableItems()
+
+		local storeList = instance.storeBuyList
+		if storeList then
+			for child in storeList.Content.Children do
+				local item = child.UserData
+
+				if item and item.ItemPrefab then
+					local id = item.ItemPrefab.Identifier.Value
+					-- Hide items within the table every refresh
+					if blockedItems[id] then child.Visible = false end
+				end
+			end
+		end
+	end, 0)
+end, Hook.HookMethodType.After)
+
+-- Force config sync on level swap to ensure things go properly
+Hook.Add("roundStart", "forcesyncconfig", function()
+	if Game.IsMultiplayer then
+		local msg = Networking.Start("NT.ConfigRequest")
+		Networking.Send(msg)
+	end
+end)

--- a/Neurotrauma/Lua/Scripts/Server/dynamicitems.lua
+++ b/Neurotrauma/Lua/Scripts/Server/dynamicitems.lua
@@ -1,0 +1,21 @@
+-- Based on config settings, which items ought to be destroyed
+local function DynamicRemoveItems()
+	local blockedItems = HF.DynamicUnavailableItems()
+
+	for _, item in pairs(Item.ItemList) do
+		local id = item.Prefab.Identifier.Value
+		if blockedItems[id] then Entity.Spawner.AddEntityToRemoveQueue(item) end
+	end
+end
+
+-- On level swap, remove any items that shouldn't be there
+Hook.Add("roundStart", "nt_dynamicremoveitems", function()
+	DynamicRemoveItems()
+end)
+
+-- Recreate stores command to make sure newly added items are actually in stores
+Game.AddCommand("nt_recreatestores", "Recreate all stores.", function()
+	for location in Game.GameSession.Map.Locations do
+		location.CreateStores(true)
+	end
+end)

--- a/Neurotrauma/Lua/Scripts/Server/items.lua
+++ b/Neurotrauma/Lua/Scripts/Server/items.lua
@@ -535,7 +535,16 @@ NT.SutureAfflictions = {
 	la_arterialcut = { xpgain = 3, case = "retractedskin" },
 	ra_arterialcut = { xpgain = 3, case = "retractedskin" },
 	h_arterialcut = { xpgain = 3, case = "retractedskin" },
-	t_arterialcut = { xpgain = 6, case = "retractedskin" },
+
+	t_arterialcut = {
+		xpgain = 6,
+		case = "retractedskin",
+		-- If Hardmode is turned on, disable open/close fixing it
+		condition = function()
+			return not NTConfig.Get("NT_HardmodeAorticRupture", false)
+		end,
+	},
+
 	arteriesclamp = { xpgain = 0, case = "retractedskin" },
 	tamponade = { xpgain = 3, case = "retractedskin" },
 	internalbleeding = { xpgain = 3, case = "retractedskin" },
@@ -603,7 +612,12 @@ NT.ItemMethods.suture = function(item, usingCharacter, targetCharacter, limb)
 		for key, value in pairs(NT.SutureAfflictions) do
 			local prefab = AfflictionPrefab.Prefabs[key]
 
-			if prefab ~= nil and (value.case == nil or HF.HasAfflictionLimb(targetCharacter, value.case, limbtype)) then
+			if
+				prefab ~= nil
+				and (value.case == nil or HF.HasAfflictionLimb(targetCharacter, value.case, limbtype))
+				-- Additional check for config
+				and (value.condition == nil or value.condition(item, usingCharacter, targetCharacter, limb))
+			then
 				if value.func ~= nil then
 					value.func(item, usingCharacter, targetCharacter, limb)
 				else
@@ -1718,9 +1732,12 @@ NT.ItemMethods.osteosynthesisimplants = function(item, usingCharacter, targetCha
 			end
 
 			HF.SetAfflictionLimb(targetCharacter, "bonegrowth", limbtype, 100, usingCharacter)
-			item.Condition = item.Condition - 25
 
-			if item.Condition <= 0 then HF.RemoveItem(item) end
+			-- Make it possible to increase / decrease the amount of uses of this item
+			local ItemUses = (1 / NTConfig.Get("NTIT_OsteoImplants_uses", 4)) * 100
+			item.Condition = item.Condition - ItemUses
+
+			if item.Condition <= 1 then HF.RemoveItem(item) end
 		else
 			HF.AddAfflictionLimb(targetCharacter, "bleeding", limbtype, 5, usingCharacter)
 			HF.AddAfflictionLimb(targetCharacter, "internaldamage", limbtype, 5, usingCharacter)
@@ -1739,7 +1756,12 @@ NT.ItemMethods.spinalimplant = function(item, usingCharacter, targetCharacter, l
 	then
 		if HF.GetSurgerySkillRequirementMet(usingCharacter, 45) then
 			HF.SetAffliction(targetCharacter, "t_paralysis", 0, usingCharacter)
-			HF.RemoveItem(item)
+
+			-- Make it possible to increase / decrease the amount of uses of this item
+			local ItemUses = (1 / NTConfig.Get("NTIT_SpinalImplants_uses", 1)) * 100
+			item.Condition = item.Condition - ItemUses
+
+			if item.Condition <= 1 then HF.RemoveItem(item) end
 
 			if NTSP ~= nil and NTConfig.Get("NTSP_enableSurgerySkill", true) then
 				HF.GiveSkillScaled(usingCharacter, "surgery", 12000)
@@ -2489,6 +2511,51 @@ NT.ItemStartsWithMethods.bloodpack = function(item, usingCharacter, targetCharac
 	local identifier = item.Prefab.Identifier.Value
 	local packtype = string.sub(identifier, string.len("bloodpack") + 1)
 	InfuseBloodpack(item, packtype, usingCharacter, targetCharacter, limb)
+end
+
+-- Dynamic Items
+-- Endovascular Balloon
+NT.ItemMethods.endovascballoon = function(item, usingCharacter, targetCharacter, limb)
+	local limbtype = limb.type
+
+	-- don't work on stasis
+	if HF.HasAffliction(targetCharacter, "stasis", 0.1) then return end
+
+	if
+		limbtype == LimbType.Torso
+		and HF.HasAfflictionLimb(targetCharacter, "surgeryincision", limbtype, 1)
+		and HF.HasAffliction(targetCharacter, "t_arterialcut", 1)
+	then
+		HF.AddAffliction(targetCharacter, "balloonedaorta", 100, usingCharacter)
+		HF.SetAffliction(targetCharacter, "internalbleeding", 0, usingCharacter)
+
+		if NTSP ~= nil and NTConfig.Get("NTSP_enableSurgerySkill", true) then
+			HF.GiveSkillScaled(usingCharacter, "surgery", 10000)
+		else
+			HF.GiveSkillScaled(usingCharacter, "medical", 5000)
+		end
+
+		if HF.Chance(NTC.GetMultiplier(usingCharacter, "balloonconsumechance")) then HF.RemoveItem(item) end
+	end
+end
+
+-- Medical Stent
+NT.ItemMethods.medstent = function(item, usingCharacter, targetCharacter, limb)
+	local limbtype = limb.type
+
+	-- don't work on stasis
+	if HF.HasAffliction(targetCharacter, "stasis", 0.1) then return end
+
+	if limbtype == LimbType.Torso and HF.HasAffliction(targetCharacter, "balloonedaorta", 1) then
+		HF.SetAffliction(targetCharacter, "balloonedaorta", 0, usingCharacter)
+		HF.SetAffliction(targetCharacter, "t_arterialcut", 0, usingCharacter)
+
+		if NTSP ~= nil and NTConfig.Get("NTSP_enableSurgerySkill", true) then
+			HF.GiveSkillScaled(usingCharacter, "surgery", 20000)
+		else
+			HF.GiveSkillScaled(usingCharacter, "medical", 10000)
+		end
+	end
 end
 
 -- ============================ HOOKS ===========================

--- a/Neurotrauma/Lua/Scripts/configdata.lua
+++ b/Neurotrauma/Lua/Scripts/configdata.lua
@@ -508,6 +508,675 @@ NT.ConfigData = {
 		boxsize = 0.1,
 		description = "Afflictions added to this category will be ignored by the health scanner.",
 	},
+
+	-- ================================= COMMON ITEMS ========================================
+	NT_ItemPriceHeaderFirstAid = {
+		name = "Common Item Price Multipliers",
+		type = "category",
+	},
+
+	NT_ItemPrice_antidama1 = {
+		name = "Morphine",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_gypsum = {
+		name = "Gypsum",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_suture = {
+		name = "Suture",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_tourniquet = {
+		name = "Tourniquet",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_needle = {
+		name = "Needle",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_drainage = {
+		name = "Drainage",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_gelipack = {
+		name = "Gel Coolant Pack",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_ointment = {
+		name = "Antibiotic Ointment",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_antibleeding1 = {
+		name = "Bandage",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_antibleeding2 = {
+		name = "Plastiseal",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_bloodpacks = {
+		name = "Blood Packs",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_emptybloodpack = {
+		name = "Empty Blood Pack",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_osteosynthesisimplants = {
+		name = "Osteosynthesis Implants",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_spinalimplant = {
+		name = "Spinal Cord Implants",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	-- ================================= BODY PARTS ========================================
+	NT_ItemPriceHeaderBodyParts = {
+		name = "Bodypart Price Multipliers",
+		type = "category",
+	},
+
+	NT_ItemPrice_arms = {
+		name = "Arms",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_legs = {
+		name = "Legs",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_bionicarms = {
+		name = "Bionic Arms",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_bioniclegs = {
+		name = "Bionic Legs",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_livertransplant = {
+		name = "Liver Transplant",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_lungtransplant = {
+		name = "Lung Transplant",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_kidneytransplant = {
+		name = "Kidney Transplant",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_hearttransplant = {
+		name = "Heart Transplant",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	-- ================================= GEAR ========================================
+	NT_ItemPriceHeaderGear = {
+		name = "Gear Price Multipliers",
+		type = "category",
+	},
+
+	NT_ItemPrice_healthscanner = {
+		name = "Health Scanner",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_bloodanalyzer = {
+		name = "Hematology Analyzer",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_defibrillator = {
+		name = "Manual Defibrillator",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_aed = {
+		name = "Automated External Defibrillator",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_bvm = {
+		name = "BVM",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_autocpr = {
+		name = "AutoPulse",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_organcrate = {
+		name = "Refrigerated Crate",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_organtoolbox = {
+		name = "Refrigerated Container",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_medtoolbox = {
+		name = "Medical Container",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_surgerytoolbox = {
+		name = "Surgery Toolbox",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_surgerytoolboxset = {
+		name = "Surgery Toolbox (Kit)",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_medstartercrate = {
+		name = "Medical Starter Crate",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_bodybag = {
+		name = "Bodybag",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_stasisbag = {
+		name = "Stasis Bag",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_wheelchair = {
+		name = "Wheelchair",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_analgesictank = {
+		name = "Analgesic Tank",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_toxfilter = {
+		name = "Toxin Filter",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_dialyzer = {
+		name = "Dialyzer",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	-- ================================= OTHER MEDICINES ========================================
+	NT_ItemPriceHeaderMedicines = {
+		name = "Other Medicine Items Price Multipliers",
+		type = "category",
+	},
+
+	NT_ItemPrice_antibloodloss1 = {
+		name = "Saline",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_opium = {
+		name = "Opium",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_antidama2 = {
+		name = "Fentanyl",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_ringerssolution = {
+		name = "Ringer's Solution",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_mannitol = {
+		name = "Mannitol",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_immunosuppressant = {
+		name = "Azathioprine",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_thiamine = {
+		name = "Thiamine",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_streptokinase = {
+		name = "Streptokinase",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_antinarc = {
+		name = "Naloxone",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_antibiotics = {
+		name = "Broad-Spectrum Antibiotics",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_adrenaline = {
+		name = "Adrenaline",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_liquidoxygenite = {
+		name = "Liquid Oxygenite",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_deusizine = {
+		name = "Deusizine",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_antibleeding3 = {
+		name = "Antibiotic Glue",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_meth = {
+		name = "Methamphetamine",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_hyperzine = {
+		name = "Hyperzine",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_antipsychosis = {
+		name = "Haloperidol",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_antiparalysis = {
+		name = "Anaparalyzant",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_nitroglycerin = {
+		name = "Nitroglycerin",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	-- ================================= SURGERY TOOLS ========================================
+	NT_ItemPriceHeaderSurgeryTools = {
+		name = "Surgical Tools Price Multipliers",
+		type = "category",
+	},
+
+	NT_ItemPrice_advhemostat = {
+		name = "Hemostat",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_advretractors = {
+		name = "Retractors",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_surgicaldrill = {
+		name = "Surgical Drill",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_surgerysaw = {
+		name = "Surgical Saw",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_tweezers = {
+		name = "Tweezers",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_traumashears = {
+		name = "Trauma Shears",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemPrice_advscalpel = {
+		name = "Multipurpose Scalpel ",
+		default = 1,
+		range = { 0, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_ItemDurabilityHeader = {
+		name = "Change Item Use Amounts",
+		type = "category",
+	},
+
+	NT_OsteoImplants_uses = {
+		name = "Osteosynthesis Implant Uses",
+		default = 4,
+		range = { 1, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	NT_SpinalImplants_uses = {
+		name = "Spinal Cord Implant Uses",
+		default = 1,
+		range = { 0.99, 10 },
+		type = "float",
+		group = true,
+		resettable = true,
+	},
+
+	-- ================================= DYNAMIC ITEM AVAILABILITY =================================
+	NT_HardmodeAorticRupture = {
+		name = "Hardmode Aortic Rupture",
+		default = false,
+		type = "bool",
+		description = "Enable the Medical Stent and Aortic Balloon as the only method to fix Aortic Rupture.",
+	},
+
+	NT_DoNitroprusside = {
+		name = "Enable Sodium Nitroprusside",
+		default = false,
+		type = "bool",
+		description = "Allow Sodium Nitroprusside to be fabricated, bought and found.",
+	},
+
+	NT_DoAntisepticSprayer = {
+		name = "Enable Antiseptic Sprayer",
+		default = false,
+		type = "bool",
+		description = "Allow Antiseptic and the Antiseptic Sprayer to be fabricated, bought and found.",
+	},
 }
 
 NTConfig.AddConfigOptions(NT)

--- a/Neurotrauma/Lua/Scripts/helperfunctions.lua
+++ b/Neurotrauma/Lua/Scripts/helperfunctions.lua
@@ -1185,3 +1185,24 @@ function HF.GetVelocity(character)
 
 	return character.AnimController.MainLimb.body.LinearVelocity
 end
+
+function HF.DynamicUnavailableItems()
+	local blockedItems = {}
+
+	-- Hardmode Aortic Rupture; enable/disable stent + balloon
+	if NTConfig.Get("NT_HardmodeAorticRupture", false) == false then
+		blockedItems["medstent"] = true
+		blockedItems["endovascballoon"] = true
+	end
+
+	-- Sodium Nitroprusside
+	if NTConfig.Get("NT_DoNitroprusside", false) == false then blockedItems["pressuremeds"] = true end
+
+	-- Antiseptic (sprayer)
+	if NTConfig.Get("NT_DoAntisepticSprayer", false) == false then
+		blockedItems["antisepticspray"] = true
+		blockedItems["antiseptic"] = true
+	end
+
+	return blockedItems
+end

--- a/Neurotrauma/Xml/Items/Chemicals.xml
+++ b/Neurotrauma/Xml/Items/Chemicals.xml
@@ -490,5 +490,131 @@
 
         <SkillRequirementHint identifier="medical" level="10"/>
     </Item>
+
+    <!-- Sodium Nitroprusside -->
+    <Item name="" identifier="pressuremeds" category="Medical" cargocontaineridentifier="mediccrate" Tags="smallitem,chem,medical" description="" useinhealthinterface="true" scale="0.2" impactsoundtag="impact_metal_light" maxstacksize="32" maxstacksizecharacterinventory="8">
+        <PreferredContainer primary="medcab" spawnprobability="0.2"/>
+        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.1"/>
+        <PreferredContainer primary="outposttrashcan" minamount="0" maxamount="2" spawnprobability="0.01"/>
+
+        <Price baseprice="100" soldbydefault="false" CanBeSpecial="false">
+            <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="2" />
+        </Price>
+
+        <Fabricate suitablefabricators="medicalfabricator" requiredtime="20" amount="3">
+            <RequiredSkill identifier="medical" level="30"/>
+            <RequiredItem identifier="sodium"/>
+            <RequiredItem identifier="nitroglycerin"/>
+        </Fabricate>
+
+        <Deconstruct time="5"/>
+
+        <InventoryIcon texture="%ModDir:3190189044%/Images/InGameItemIconAtlas.png" sourcerect="812,512,50,126" origin="0.5,0.5"/>
+        <Sprite texture="%ModDir:3190189044%/Images/InGameItemIconAtlas.png" sourcerect="812,512,50,126" depth="0.6" origin="0.5,0.5"/>
+        <Body width="35" height="70" density="20"/>
+
+        <MeleeWeapon canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="0,0" holdangle="220" reload="1.0" msg="ItemMsgPickUpSelect">
+            <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
+            <RequiredSkill identifier="medical" level="10"/>
+            <StatusEffect statuseffecttags="medical" multiplyafflictionsbymaxvitality="true" type="OnSuccess" target="UseTarget" duration="10">
+                <Sound file="%ModDir:3190189044%/Sound/pills1.ogg" range="500"/>
+                <Sound file="%ModDir:3190189044%/Sound/pills2.ogg" range="500"/>
+                <Sound file="%ModDir:3190189044%/Sound/pills3.ogg" range="500"/>
+                <Affliction identifier="afpressuredrug" amount="5"/>
+            </StatusEffect>
+
+            <StatusEffect statuseffecttags="medical" multiplyafflictionsbymaxvitality="true" type="OnFailure" target="UseTarget" duration="10">
+                <Sound file="%ModDir:3190189044%/Sound/pills1.ogg" range="500"/>
+                <Sound file="%ModDir:3190189044%/Sound/pills2.ogg" range="500"/>
+                <Sound file="%ModDir:3190189044%/Sound/pills3.ogg" range="500"/>
+                <Affliction identifier="afpressuredrug" amount="3"/>
+            </StatusEffect>
+
+            <StatusEffect type="OnBroken" target="This">
+                <Remove/>
+            </StatusEffect>
+        </MeleeWeapon>
+
+        <SkillRequirementHint identifier="medical" level="10"/>
+    </Item>
+
+    <!-- Antiseptic Sprayer -->
+    <Item name="" identifier="antisepticspray" category="Equipment" Tags="smallitem,tool,medical" useinhealthinterface="true" cargocontaineridentifier="metalcrate" description="" Scale="0.5" impactsoundtag="impact_soft">
+        <PreferredContainer primary="medcab" minamount="0" maxamount="1" spawnprobability="1"/>
+        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="3" spawnprobability="0.5"/>
+        <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="1" spawnprobability="0.25"/>
+
+        <Price baseprice="75" CanBeSpecial="false">
+            <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="2"/>
+        </Price>
+
+        <InventoryIcon texture="%ModDir:3190189044%/Images/InventoryItemIconAtlas.png" sourcerect="128,64,64,64" origin="0.5,0.5"/>
+        <Sprite texture="%ModDir:3190189044%/Images/InGameItemIconAtlas.png" sourcerect="384,256,128,128" depth="0.55" origin="0.5,0.5"/>
+        <Deconstruct time="5">
+        </Deconstruct>
+
+        <Fabricate suitablefabricators="fabricator" requiredtime="10">
+            <RequiredItem identifier="plastic"/>
+        </Fabricate>
+
+        <Body width="150" height="60" density="40"/>
+        <SuitableTreatment identifier="infectedwound" suitability="45"/>
+
+        <Holdable slots="Any,RightHand+LeftHand" controlpose="true" aimpos="30,0" handle1="0,-7" handle2="95, 10" msg="ItemMsgPickUpSelect"/>
+
+        <RepairTool range="200" barrelpos="15,5" combatpriority="10">
+            <ParticleEmitter particle="extinguisher" particlespersecond="15" copyentityangle="true" velocitymin="200.0" velocitymax="250.0"/>
+            <RequiredSkill identifier="medical" level="40"/>
+            <RequiredItems items="antiseptic" type="Contained" msg="Antiseptic Required"/>
+
+            <StatusEffect type="OnUse" target="This" Condition="-100" disabledeltatime="true"/>
+
+            <StatusEffect type="OnBroken" target="This" Condition="100" disabledeltatime="true" delay="2" stackable="false"/>
+
+            <StatusEffect type="OnUse" targettype="Contained" targets="antiseptic" disabledeltatime="true" Condition="-10.0"/>
+
+            <StatusEffect statuseffecttags="medical" type="OnUse" target="Limb" disabledeltatime="true">
+                <Sound file="%ModDir:3190189044%/Sound/spray.ogg" range="500"/>
+                <ReduceAffliction identifier="infectedwound" amount="100"/>
+                <Affliction identifier="ointmented" amount="20"/>
+            </StatusEffect>
+        </RepairTool>
+
+        <ItemContainer capacity="1" maxstacksize="1" hideitems="false" itempos="-35,3" containedspritedepth="0.56" ItemRotation="-90" containedstateindicatorstyle="tank">
+            <Containable items="antiseptic"/>
+        </ItemContainer>
+
+        <SkillRequirementHint identifier="medical" level="40" />
+    </Item>
+
+    <!-- Antiseptic -->
+    <Item name="" identifier="antiseptic" category="Medical" maxstacksize="32" maxstacksizecharacterinventory="8" cargocontaineridentifier="mediccrate" description="" Tags="smallitem,chem,medical" scale="0.3">
+        <Upgrade gameversion="0.10.0.0" scale="0.3"/>
+        <PreferredContainer primary="medcab" minamount="0" maxamount="1" spawnprobability="1"/>
+        <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="6" spawnprobability="0.25"/>
+        <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="3" spawnprobability="0.15"/>
+
+        <Price baseprice="60" CanBeSpecial="false">
+            <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="3"/>
+        </Price>
+
+        <Fabricate suitablefabricators="medicalfabricator" requiredtime="15">
+            <RequiredSkill identifier="medical" level="40"/>
+            <RequiredItem identifier="chlorine"/>
+            <RequiredItem identifier="ethanol"/>
+        </Fabricate>
+
+        <Deconstruct time="5"/>
+
+        <InventoryIcon texture="%ModDir:3190189044%/Images/InventoryItemIconAtlas.png" sourcerect="192,64,64,64" origin="0.5,0.5"/>
+        <Sprite texture="%ModDir:3190189044%/Images/InGameItemIconAtlas.png" sourcerect="256,256,128,128" depth="0.6" origin="0.5,0.5"/>
+        <Body width="30" height="55" density="20"/>
+
+        <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="5,0" handle1="5,3" holdangle="10" reload="1.0" CanBeCombined="true" RemoveOnCombined="true">
+            <StatusEffect type="OnBroken" target="This">
+                <Remove/>
+            </StatusEffect>
+        </MeleeWeapon>
+    </Item>
 </Items>
 </Override>

--- a/Neurotrauma/Xml/Items/Consumables.xml
+++ b/Neurotrauma/Xml/Items/Consumables.xml
@@ -110,5 +110,68 @@
 
         <SkillRequirementHint identifier="medical" level="40"/>
     </Item>
+
+    <Item name="" identifier="endovascballoon" category="Medical" maxstacksize="16" maxstacksizecharacterinventory="4" cargocontaineridentifier="mediccrate" Tags="smallitem,medical,surgery,surgerytool" description="" useinhealthinterface="True" scale="0.250">
+        <PreferredContainer primary="toxcontainer" minamount="0" maxamount="1" spawnprobability="0.5"/>
+
+        <Fabricate suitablefabricators="medicalfabricator" amount="2">
+            <RequiredSkill identifier="medical" level="25"/>
+            <RequiredItem identifier="organicfiber" />
+            <RequiredItem identifier="plastic" />
+            <RequiredItem identifier="rubber" />
+        </Fabricate>
+
+        <Deconstruct/>
+
+        <Price baseprice="30" soldbydefault="true" CanBeSpecial="false">
+            <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5"/>
+        </Price>
+
+        <InventoryIcon texture="%ModDir:3190189044%/Images/InventoryItemIconAtlas.png" sourcerect="192,128,64,64" origin="0.5,0.5"/>
+        <Sprite texture="%ModDir:3190189044%/Images/InGameItemIconAtlas.png" sourcerect="512,256,128,128" depth="0.55" origin="0.5,0.5"/>
+        <Body width="100" height="100" density="50"/>
+        <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="5,0" handle1="-5,0" holdangle="10" reload="1.0">
+            <StatusEffect type="OnUse" target="This">
+                <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
+            </StatusEffect>
+            
+            <StatusEffect type="OnBroken" target="This">
+                <Remove/>
+            </StatusEffect>
+        </MeleeWeapon>
+    </Item>
+
+    <Item name="" identifier="medstent" category="Medical" maxstacksize="16" maxstacksizecharacterinventory="4" cargocontaineridentifier="mediccrate" Tags="smallitem,medical,surgery,surgerytool" description="" useinhealthinterface="True" scale="0.250">
+        <PreferredContainer primary="toxcontainer" minamount="1" maxamount="1" spawnprobability="0.5"/>
+        <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="1" spawnprobability="0.125"/>
+
+        <Fabricate suitablefabricators="medicalfabricator" amount="2">
+            <RequiredSkill identifier="medical" level="25"/>
+            <RequiredItem identifier="organicfiber" />
+            <RequiredItem identifier="plastic" />
+            <RequiredItem identifier="rubber" />
+        </Fabricate>
+
+        <Deconstruct/>
+
+        <Price baseprice="70" soldbydefault="true" CanBeSpecial="false">
+            <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5"/>
+        </Price>
+
+        <InventoryIcon texture="%ModDir:3190189044%/Images/InventoryItemIconAtlas.png" sourcerect="384,128,64,64" origin="0.5,0.5"/>
+        <Sprite texture="%ModDir:3190189044%/Images/InventoryItemIconAtlas.png" sourcerect="384,128,64,64" depth="0.55" origin="0.5,0.5"/>
+        <Body width="100" height="100" density="50"/>
+        <SuitableTreatment identifier="arterialcut5" suitability="50"/>
+
+        <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="5,0" handle1="-5,0" holdangle="10" reload="1.0">
+            <StatusEffect type="OnUse" target="This">
+                <Sound file="Content/Items/Medical/Syringe.ogg" range="500"/>
+            </StatusEffect>
+
+            <StatusEffect type="OnBroken" target="This">
+                <Remove/>
+            </StatusEffect>
+        </MeleeWeapon>
+    </Item>
 </Items>
 </Override>


### PR DESCRIPTION
A plug-and-play example of this system can be found [here](https://steamcommunity.com/sharedfiles/filedetails/?id=3707374934). It will throw an error since it's looking for something in the updated config but will work regardless.

Balancing the mod is hard; it will be too easy for some, too hard for others. Likewise, ensuring new people are not overwhelmed is also a consideration that has caused some changes recently (namely, the removal of the items which caused a lot of backclash).

This PR is more of a proof-of-concept, though it can still be merged without any issues.

## Considerations:

Based on comments, the following things come to mind when 'balancing' items:
1. An item cannot be found too easily.
2. The price musn't be too cheap, nor too expensive.
3. Some items have 'too many' crafting outputs.

Additionally, Heelge has demanded that there should be no items that can confuse new players.

Point 1 was already addressed in PR #125; slashing loot across the board.

Point 2 is context-reliant; depending on mods, player skill and player counts. It's virtually impossible to define a perfect price for all in XML.

Point 3 is something that can be looked at based on my experiences creating this PR so far; and should also be able to be made dynamic (though adding this into config options without blowing my brains out may be hard. Perhaps it would take the shape of crafting multipliers; i.e increase / reduce crafting outputs but keep the same ingredient input amounts).

So, what can we do to make point 2 less bad and prevent people from going insane in the steam comments?

## Additions:

### Price Configuration:
1. By hooking into the way prices are calculated, the NT config can now be used to add item cost multipliers to **all** configured Neurotrauma items. Prices can now fluctuate between 0 and 10 times their original value; as configured by the host.

This allows people to determine their own balance; feel like something is too cheap? Just make it more expensive! Are you running a new crew and don't want to worry about medical supplies? Cut prices across the board!

### Durability Configuration:
2. Some small tweaks to item methods allow config values to be used in the calculation of item durabilities. This PR contains two examples; Osteosynthesis Implants and Spinal Cord Implants. Defaulting at 4 and 1 uses respectfully, they can be tweaked to have between 1 and 10 uses for each individual item as configured by the host. 

This allows players who use Dynamic Europa (and thus see less merchants) or those who are perpetually broke or those who have larger crews running Barotraumatic and keep encountering massive amounts of BFT to choose to increase the amount of uses in their Bone-healing juice; or to give each Spinal Implant a bit more bang for their buck. Likewise, it could be decreased if you're a masochist - I guess?

While not directly changing the price or crafting recipe, this does indirectly make items 'cheaper'. Let the players balance it themselves!

### Item Availability Configuration:
3. The best of both worlds. Allow people to use the items they like while not spawning them / making them craftable / buyable by default (such as Antiseptic, the Antiseptic Sprayer and Nitroprusside); this prevents new people from using "less optimal" items by default but does give them the option to bring them into the game. Since by default, none of these items will spawn / be able to be crafted / bought (and will be wiped on level change if the setting is disabled again) it will not clog inventories or stores with useless items.

### Surgery Configuration:
4. Speaking of useless items; the Medical Stent and Endovascular Balloon were removed because Aortic Rupture could be fixed by using Open / Close surgery as well. Utilizing the earlier method of item hiding + a mild tweak to the Sutures in item methods it is now possible to 'toggle' the harder option for Aortic Surgery.

Disabled by default, this setting will keep Open / Close Surgery as the main fix for Aortic Rupture. However, if "Hardmode Aortic Rupture" is enabled, instead it will remove Open / Close Surgery as a valid cure and force you to use the Endovascular Balloon / Stent to cure the patient. Of course, if the hardmode option is not enabled then those items are not possible to acquire and thus won't confuse anyone.

### Issues:
- Since the clientside config values only update if the actual config menu is opened by said client, the UIs would still show those items (fabricator) / old item prices (though they would actually still have to pay the changed prices). The addition of an on-level load hook to force clients to get the config means that on level switch these problems remove themselves but it does make Clientside Lua required.

- Re-adding items to Neurotrauma will not update stores of people mid-campaign. Thus, a command was added to force-rebuild the stores (since asking people to download a separate mod for that might not work so well.) "nt_recreatestores" can be used to well, recreate stores.

- The UI does not like it when the default value of a float is the same as its minimum value. To circumvent this, I've temporarily added a check that turns the minimum value of 0.99 into 1 in the UI, and since the float steps are too large + they round up this changes nothing. This does however prevent the value from showing as '0' despite it being 1 (in the cases of this PR).

### Examples:
## Config look:
<img width="659" height="110" alt="image" src="https://github.com/user-attachments/assets/0861cc07-9393-453e-be73-4fec4fcacb98" />

## A merchant, with the option enabled.
<img width="460" height="478" alt="image" src="https://github.com/user-attachments/assets/cb959971-f8c0-4019-b7c7-e2961d8914eb" />

## Same merchant, option disabled.
<img width="505" height="528" alt="image" src="https://github.com/user-attachments/assets/72051786-2600-4a30-8857-2336e68b5acf" />


