### PR TITLE
Possible Price / Recipe changes

### DIFF
--- a/Neurotrauma/Xml/Items/Chemicals.xml
+++ b/Neurotrauma/Xml/Items/Chemicals.xml
@@ -7,7 +7,7 @@
         <PreferredContainer primary="medcab" minamount="0" maxamount="0"/>
         <PreferredContainer primary="abandonedmedcab" minamount="0" maxamount="4" spawnprobability="0.25"/>
 
-        <Price baseprice="50">
+        <Price baseprice="100">
             <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="15"/>
         </Price>
 
@@ -122,7 +122,7 @@
             <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="2"/>
         </Price>
 
-        <Fabricate suitablefabricators="medicalfabricator" requiredtime="20" amount="3">
+        <Fabricate suitablefabricators="medicalfabricator" requiredtime="20" amount="2">
             <RequiredSkill identifier="medical" level="50"/>
             <RequiredItem identifier="ethanol"/>
             <RequiredItem identifier="phosphorus"/>
@@ -165,11 +165,11 @@
         <PreferredContainer primary="abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.05"/>
         <PreferredContainer primary="outposttrashcan" minamount="0" maxamount="2" spawnprobability="0.01"/>
 
-        <Price baseprice="100" soldbydefault="false">
+        <Price baseprice="70" soldbydefault="false">
             <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="2"/>
         </Price>
 
-        <Fabricate suitablefabricators="medicalfabricator" requiredtime="25" amount="5">
+        <Fabricate suitablefabricators="medicalfabricator" requiredtime="25" amount="3">
             <RequiredSkill identifier="medical" level="40"/>
             <RequiredItem identifier="carbon" amount="2"/>
             <RequiredItem identifier="sulphuricacid"/>
@@ -209,7 +209,7 @@
         <PreferredContainer primary="abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.10"/>
         <PreferredContainer primary="outposttrashcan" minamount="0" maxamount="2" spawnprobability="0.01"/>
 
-        <Price baseprice="100" soldbydefault="false">
+        <Price baseprice="120" soldbydefault="false">
             <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
         </Price>
 
@@ -594,7 +594,7 @@
         <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="6" spawnprobability="0.25"/>
         <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="3" spawnprobability="0.15"/>
 
-        <Price baseprice="60" CanBeSpecial="false">
+        <Price baseprice="100" CanBeSpecial="false">
             <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="3"/>
         </Price>
 

--- a/Neurotrauma/Xml/Items/Consumables.xml
+++ b/Neurotrauma/Xml/Items/Consumables.xml
@@ -56,7 +56,7 @@
 
         <Deconstruct/>
 
-        <Price baseprice="25" soldbydefault="true">
+        <Price baseprice="70" soldbydefault="true">
             <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5"/>
         </Price>
 
@@ -81,7 +81,7 @@
         <PreferredContainer primary="abandonedmedcab" minamount="0" maxamount="1" spawnprobability="0.5"/>
         <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="1" spawnprobability="0.125"/>
 
-        <Price baseprice="40">
+        <Price baseprice="50">
             <Price storeidentifier="merchantoutpost" multiplier="1.2" minavailable="6"/>
             <Price storeidentifier="merchantcity" multiplier="1.2" minavailable="12"/>
             <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="12"/>
@@ -123,7 +123,7 @@
 
         <Deconstruct/>
 
-        <Price baseprice="30" soldbydefault="true" CanBeSpecial="false">
+        <Price baseprice="80" soldbydefault="true" CanBeSpecial="false">
             <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5"/>
         </Price>
 
@@ -154,7 +154,7 @@
 
         <Deconstruct/>
 
-        <Price baseprice="70" soldbydefault="true" CanBeSpecial="false">
+        <Price baseprice="80" soldbydefault="true" CanBeSpecial="false">
             <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5"/>
         </Price>
 

--- a/Neurotrauma/Xml/Items/Containers.xml
+++ b/Neurotrauma/Xml/Items/Containers.xml
@@ -128,7 +128,7 @@
             <Item identifier="steel" amount="2"/>
         </Fabricate>
        
-        <Price baseprice="25">
+        <Price baseprice="80">
             <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="2"/>
         </Price>
         
@@ -256,7 +256,7 @@
     </Item>
 
     <Item name="" identifier="medstartercrate" tags="crate" scale="0.4" linkable="true" pickdistance="150" showcontentsintooltip="true" impactsoundtag="impact_metal_heavy" waterproof="true" fireproof="true" description="">
-        <Price baseprice="600">
+        <Price baseprice="700">
             <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="3"/>
         </Price>
        
@@ -264,11 +264,11 @@
         
         <Fabricate suitablefabricators="fabricator" requiredtime="10">
             <RequiredSkill identifier="mechanical" level="20" />
-            <Item identifier="steel" amount="8"/>
+            <Item identifier="steel" amount="6"/>
             <Item identifier="copper" amount="2"/>
             <Item identifier="zinc" amount="3"/>
             <Item identifier="organicfiber" amount="6"/>
-            <Item identifier="plastic" amount="8"/>
+            <Item identifier="plastic" amount="6"/>
         </Fabricate>
         
         <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" depth="0.54" sourcerect="158,578,146,82" origin="0.5,0.5" />
@@ -361,7 +361,7 @@
     </Item>
     
     <Item name="" identifier="stasisbag" category="Equipment" useinhealthinterface="True" tags="provocative,mediumitem,diving" scale="0.9" fireproof="true" description="" cargocontaineridentifier="metalcrate" impactsoundtag="impact_soft" equipconfirmationtext="stasisbagequipconfirmation">
-        <Price baseprice="1500" soldbydefault="false">
+        <Price baseprice="700" soldbydefault="false">
             <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
         </Price>
        

--- a/Neurotrauma/Xml/Items/Etc.xml
+++ b/Neurotrauma/Xml/Items/Etc.xml
@@ -217,7 +217,6 @@
             <RequiredSkill identifier="medical" level="20" />
             <RequiredSkill identifier="mechanical" level="30" />
             <RequiredItem identifier="steel" />
-            <RequiredItem identifier="titaniumaluminiumalloy" />
         </Fabricate>
 
         <Deconstruct time="10">

--- a/Neurotrauma/Xml/Items/FirstAID.xml
+++ b/Neurotrauma/Xml/Items/FirstAID.xml
@@ -13,7 +13,7 @@
 
         <Deconstruct time="2"/>
 
-        <Price baseprice="60" soldbydefault="true">
+        <Price baseprice="50" soldbydefault="true">
             <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5"/>
         </Price>
 
@@ -42,11 +42,11 @@
         <PreferredContainer primary="abandonedmedcab" minamount="0" maxamount="1" spawnprobability="0.5"/>
         <PreferredContainer primary="outpostmedcompartment" minamount="0" maxamount="1" spawnprobability="0.25"/>
 
-        <Price baseprice="80" soldbydefault="false">
+        <Price baseprice="60" soldbydefault="false">
             <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
         </Price>
 
-        <Fabricate suitablefabricators="medicalfabricator" requiredtime="40" amount="4">
+        <Fabricate suitablefabricators="medicalfabricator" requiredtime="40" amount="2">
             <RequiredSkill identifier="medical" level="20"/>
             <RequiredItem identifier="plastic" />
             <RequiredItem identifier="aluminium" />

--- a/Neurotrauma/Xml/Items/Surgery/Implants.xml
+++ b/Neurotrauma/Xml/Items/Surgery/Implants.xml
@@ -5,7 +5,7 @@
         <PreferredContainer primary="medcab"/>
         <PreferredContainer secondary="locker"/>
         <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.05" />
-        <Price baseprice="200" soldbydefault="false">
+        <Price baseprice="350" soldbydefault="false">
             <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
         </Price>
 
@@ -41,7 +41,7 @@
         <PreferredContainer secondary="locker"/>
         <PreferredContainer primary="wreckmedcab,abandonedmedcab" minamount="0" maxamount="2" spawnprobability="0.05" />
 
-        <Price baseprice="200" soldbydefault="false">
+        <Price baseprice="350" soldbydefault="false">
             <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="1"/>
         </Price>
 


### PR DESCRIPTION
Changes prices to be more in line with the rest; generally speaking, items are cheaper to craft than they are to buy (since that gets players to consume their resources more, which since it is finite requires them to make choices; do I want more bullets crafted or more medical supplies crafted? Basic balancing).

All numbers are unmodified base prices of items.

### Changes:
- Ringers Solution: Currently bought for 50 marks; total crafting recipe costs 70. Increase store price to 100 marks instead.

- Azathioprine: Currently bought for 100 marks; total crafting recipe costs 165 for 3 or 55 per 1. Reduce crafting recipe to only 2 outputs instead of 3.

- Thiamine: Currently bought for 100 marks; total crafting recipe costs 100 marks for 5 or 20 marks per 1. Reduce crafting recipe to only 3 instead of 5, decrease store price to 70 marks.

- Streptokinase: Currently bought for 100 marks; total crafting recipe costs 190 for 2 or 80 marks per 1. Increase store price to 120 marks instead.

- Antiseptic: Currently bought for 60 marks;  total crafting recipe costs 70. Increase store price to 100 marks instead.

- Drainage: Currently bought for 25 marks;  total crafting recipe costs 45. Increase store price to 70 marks instead.

- Gypsum: Currently bought for 40 marks;  total crafting recipe costs 31. Increase store price to 50 marks instead.

- Endovascular Balloon: Currently bought for 30 marks;  total crafting recipe costs 95 per 2 or 47 per 1. Increase store price to 80 marks instead.

- Medical Stent: Currently bought for 30 marks;  total crafting recipe costs 95 per 2 or 47 per 1. Increase store price to 80 marks instead.

- Surgery Tool Box:  Currently bought for 25 marks;  total crafting recipe costs 46 marks. Increase store price to 80 marks instead.

- Surgery Tool Box Set:  Currently bought for 200 marks;  total crafting recipe costs 250. Increase store price to 300 marks instead.

- Medical Starter Crate:  Currently bought for 600 marks;  total crafting recipe costs ~900 marks. Item value within is ~1.5k marks. Make crafting recipe require 2 less steel and 2 less plastic, increase store price to 700 marks. Should still be balanced since it's an item that's not used often, but very important for those who've lost everything.

- Stasis Bags: Currently bought for 1500 marks; total crafting recipe costs ~400 marks. Decrease store price to 700 marks instead. While a great first aid item, there is literally no reason to buy it right now since its almost 4x as expensive as just buying the base ingredients.

- Wheelchair: Currently bought for 100 marks; total crafting recipe costs 200 marks. Removed Titanium-Aluminium Alloy as an ingredient. It's an item that doesnt get used much yet can mitigate some issues. Making it cost TiAl is just overkill.

- Needle: Currently bought for 80 marks; total crafting recipe costs 80 marks per 4 or 20 per 1. Decrease crafting output from 4 to 2 (now 40 marks per 1) and decrease store price to 60 marks.

- Osteosynthesis Implants:  Currently bought for 200 marks; total crafting recipe costs 260 marks. Increase store price to 350.

- Spinal-cord Implants:  Currently bought for 200 marks; total crafting recipe costs 260 marks. Increase store price to 350.
