### PR TITLE
Fix dynamic item vanishing

### DIFF
--- a/Neurotrauma/Lua/Scripts/Server/dynamicitems.lua
+++ b/Neurotrauma/Lua/Scripts/Server/dynamicitems.lua
@@ -9,7 +9,7 @@ local function DynamicRemoveItems()
 end
 
 -- On level swap, remove any items that shouldn't be there
-Hook.Add("roundStart", "nt_dynamicremoveitems", function()
+Hook.Add("roundEnd", "nt_dynamicremoveitems", function()
 	DynamicRemoveItems()
 end)
 


### PR DESCRIPTION
Someone reported their Antiseptic Spray vanishing on total game reload. After 80 restarts I've managed to reproduce it only once; though since only the actual removal of items is ran once per level on start my best guess is that the config took too long to load and thus considered the item 'to be removed'. 

Therefor, instead of checking at the start of a level instead check at the end of a level; since you cannot get there without at least a few seconds of play even with cheats.