### PR TITLE
bandage fix annoying error message 

### DIFF
--- a/Neurotrauma/Lua/Scripts/helperfunctions.lua
+++ b/Neurotrauma/Lua/Scripts/helperfunctions.lua
@@ -415,8 +415,14 @@ function HF.SetAfflictionLimb(character, identifier, limbtype, strength, aggress
 	local affliction = prefab.Instantiate(strength, aggressor)
 	local recalculateVitality = NTC.AfflictionsAffectingVitality[identifier] ~= nil
 
+    local limb = character.AnimController.GetLimb(limbtype)
+  
+    if limb == nil then
+        return
+    end
+
 	character.CharacterHealth.ApplyAffliction(
-		character.AnimController.GetLimb(limbtype),
+		limb,
 		affliction,
 		false,
 		false,


### PR DESCRIPTION
Fix to an error that pops up when loading in if getLimb() returns nil.

The error in question :
<img width="866" height="359" alt="Screenshot_1" src="https://github.com/user-attachments/assets/29be122f-5811-41a1-813b-8e9d8291739a" />
