### PR TITLE
Update dynamicitems.lua

### DIFF
--- a/Neurotrauma/Lua/Scripts/Server/dynamicitems.lua
+++ b/Neurotrauma/Lua/Scripts/Server/dynamicitems.lua
@@ -4,7 +4,7 @@ local function DynamicRemoveItems()
 
 	for _, item in pairs(Item.ItemList) do
 		local id = item.Prefab.Identifier.Value
-		if blockedItems[id] then Entity.Spawner.AddEntityToRemoveQueue(item) end
+		if blockedItems[id] then item.Remove() end
 	end
 end
 


### PR DESCRIPTION
Fix for #142.

For some reason, despite it working fine before, just assigning the items to the removal queue wont do anything; probably has to do with the fact its now on round end. Instead, just forcibly remove them via an item function. Tested SP / MP and works.

