### PR TITLE
Fix dropped item sprites for 0- and 0+ Blood Packs

### DIFF
--- a/Neurotrauma/Xml/Items/Blood/BloodPacks.xml
+++ b/Neurotrauma/Xml/Items/Blood/BloodPacks.xml
@@ -6,7 +6,7 @@
         <PreferredContainer secondary="medcontainer"/>
 
         <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="194,325,64,64" origin="0.5,0.5"/>
-        <Sprite sourcerect="128,171,64,85" />
+        <Sprite sourcerect="128,85,64,85" />
         <Price baseprice="200">
             <Price storeidentifier="merchantmedical" sold="true" multiplier="0.9" minavailable="5"/>
         </Price>

--- a/Neurotrauma/Xml/Items/Override.xml
+++ b/Neurotrauma/Xml/Items/Override.xml
@@ -259,7 +259,7 @@
             </Deconstruct>
             <SuitableTreatment identifier="bloodloss" suitability="100"/>
             <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="326,327,64,64" origin="0.5,0.5"/>
-            <Sprite texture="%ModDir%/Images/BloodPacksAtlas.png" sourcerect="128,85,64,85" />
+            <Sprite texture="%ModDir%/Images/BloodPacksAtlas.png" sourcerect="128,171,64,85" />
             <Body width="80" height="42" density="11"/>
             <Holdable canBeCombined="true" removeOnCombined="true" slots="Any,RightHand,LeftHand" handle1="0,0" msg="ItemMsgPickUpSelect">
                 <StatusEffect type="OnBroken" target="This">

--- a/Neurotrauma/Xml/Items/Override.xml
+++ b/Neurotrauma/Xml/Items/Override.xml
@@ -309,7 +309,7 @@
             <SkillRequirementHint identifier="medical" level="10"/>
         </Item>
 
-        <Item name="" identifier="antibleeding2" category="Medical" Tags="smallitem,medical" maxstacksize="32" maxstacksizecharacterinventory="8" cargocontaineridentifier="mediccrate" description="" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_soft" RequireAimToUse="True">
+        <Item name="" identifier="antibleeding2" category="Medical" Tags="smallitem,medical" maxstacksize="32" maxstacksizecharacterinventory="8" cargocontaineridentifier="mediccrate" description="" useinhealthinterface="true" scale="0.5" impactsoundtag="impact_soft" RequireAimToUse="True" CanFlipX="false">
             <Upgrade gameversion="0.10.0.0" scale="0.5" />
             <PreferredContainer primary="medcab" secondary="medcontainer"/>
             <PreferredContainer secondary="abandonedmedcab" minamount="1" maxamount="2" spawnprobability="0.4" />


### PR DESCRIPTION
Apparently, the dropped sprite for 0+ is currently the 0- Blood Pack and vice versa. No clue when this snuck in, but I noticed it yesterday. Swap the sourcerects to resolve this.