### PR TITLE
Improve Surgery Table / Hospital Bed Performance Impact

### DIFF
--- a/Neurotrauma/Xml/Items/Etc.xml
+++ b/Neurotrauma/Xml/Items/Etc.xml
@@ -193,12 +193,12 @@
 
         <Holdable selectkey="Action" pickkey="Use" slots="RightHand+LeftHand" msg="ItemMsgDetach" PickingTime="5" aimpos="85,-10" handle1="0,0" attachable="true" aimable="true">
             <!-- Artificial Ventilation and Table afflictions -->
-            <StatusEffect type="OnNotContained" target="NearbyCharacters" range="200" stackable="true">
-                <Affliction identifier="table" amount="2"/>
-                <Affliction identifier="alv" amount="10"/>
+            <StatusEffect type="OnNotContained" target="NearbyCharacters" range="200" interval="1" stackable="true" disabledeltatime="true" >
+              <Affliction identifier="table" amount="2" />
+              <Affliction identifier="alv" amount="100" />
             </StatusEffect>
             <!-- Output value update -->
-            <StatusEffect type="Always" target="NearbyCharacters" range="200" delay="1" stackable="false">
+            <StatusEffect type="Always" target="NearbyCharacters" range="200" interval="1" stackable="false">
                 <LuaHook name="surgerytable.update" />
             </StatusEffect>
             <!-- Hide contained items to prevent sprites glitching -->

--- a/Neurotrauma/Xml/Items/Override.xml
+++ b/Neurotrauma/Xml/Items/Override.xml
@@ -351,11 +351,11 @@
             <sprite texture="%ModDir%/Images/MedBayAssets.png" sourcerect="96,304,416,192" depth="0.97" premultiplyalpha="false" origin="0.5,0.5"/>
 
             <ItemComponent>
-                <StatusEffect type="OnNotContained" target="NearbyCharacters" range="200" stackable="true">
-                    <Affliction identifier="table" amount="2"/>
-                    <Affliction identifier="alv" amount="10"/>
+                <StatusEffect type="OnNotContained" target="NearbyCharacters" range="200" interval="1" stackable="true" disabledeltatime="true" >
+                  <Affliction identifier="table" amount="2" />
+                  <Affliction identifier="alv" amount="100" />
                 </StatusEffect>
-                <StatusEffect type="Always" target="NearbyCharacters" range="200" delay="1" stackable="false">
+                <StatusEffect type="Always" target="NearbyCharacters" range="200" interval="1" stackable="false">
                     <LuaHook name="surgerytable.update" />
                 </StatusEffect>
             </ItemComponent>


### PR DESCRIPTION
As discovered by Cookie, currently the ALV providing beds had quite the performance impact with multiple people nearby.

Testing showed that the more people are near a bed and the more beds are within range of a person (or both), the more performance would suffer.

### Issue:
- Beds apply their afflictions every single frame to everyone nearby - even if they already got them from another bed nearby.

### Fix:
- 1. Add an interval to ensure it only triggers once per second, not sixty times.
- 2. Adjust the amount of ALV given per instance to compensate for the decrease in frequency

You *could* also add a conditional check to see if they already have the ALV affliction above a certain threshold (which would decrease the amount of simultaneous applications) but this would probably cost more than it'd save.

Based on testing, this decreases relative performance cost of said beds by roughly 90%.