### PR TITLE
Bandage fix for duplicate hematology print out displays

### DIFF
--- a/Neurotrauma/Lua/Scripts/Server/items.lua
+++ b/Neurotrauma/Lua/Scripts/Server/items.lua
@@ -317,12 +317,17 @@ NT.ItemMethods.bloodanalyzer = function(item, usingCharacter, targetCharacter, l
 
 	local afflictionlist = targetCharacter.CharacterHealth.GetAllAfflictions()
 	local afflictionsdisplayed = 0
+	local checkedafflictionslist = {}
 
 	for value in afflictionlist do
 		local strength = HF.Round(value.Strength)
 		local prefab = value.Prefab
 
 		if strength > 2 and HF.TableContains(NT.HematologyDetectable, prefab.Identifier.Value) then
+
+			if checkedafflictionslist[value] == nil then return end -- Check to see if we haven't added the affliction yet!
+			table.insert(checkedafflictionslist,value) -- Add the affliction to the list.
+			
 			local id = value.Identifier
 			if not HF.TableContains(IgnoredCategory, id) then
 				local entry = "\n" .. prefab.Name.Value .. ": " .. strength .. "%"

--- a/Neurotrauma/Lua/Scripts/Server/items.lua
+++ b/Neurotrauma/Lua/Scripts/Server/items.lua
@@ -324,11 +324,11 @@ NT.ItemMethods.bloodanalyzer = function(item, usingCharacter, targetCharacter, l
 		local prefab = value.Prefab
 
 		if strength > 2 and HF.TableContains(NT.HematologyDetectable, prefab.Identifier.Value) then
-
-			if checkedafflictionslist[value] ~= nil then return end -- Check to see if we haven't added the affliction yet!
-			table.insert(checkedafflictionslist,value) -- Add the affliction to the list.
-			
 			local id = value.Identifier
+
+			if checkedafflictionslist[id] ~= nil then return end -- Check to see if we haven't added the affliction yet!
+			table.insert(checkedafflictionslist,id) -- Add the affliction to the list.
+
 			if not HF.TableContains(IgnoredCategory, id) then
 				local entry = "\n" .. prefab.Name.Value .. ": " .. strength .. "%"
 

--- a/Neurotrauma/Lua/Scripts/Server/items.lua
+++ b/Neurotrauma/Lua/Scripts/Server/items.lua
@@ -325,7 +325,7 @@ NT.ItemMethods.bloodanalyzer = function(item, usingCharacter, targetCharacter, l
 
 		if strength > 2 and HF.TableContains(NT.HematologyDetectable, prefab.Identifier.Value) then
 
-			if checkedafflictionslist[value] == nil then return end -- Check to see if we haven't added the affliction yet!
+			if checkedafflictionslist[value] ~= nil then return end -- Check to see if we haven't added the affliction yet!
 			table.insert(checkedafflictionslist,value) -- Add the affliction to the list.
 			
 			local id = value.Identifier


### PR DESCRIPTION
Recently (and mostly with my mod), there have been reports of duplicate blood afflictions appearing in the print out. They never go away unless the patient dies (I believe). 
Examples:
<img width="433" height="325" alt="image" src="https://github.com/user-attachments/assets/e2db4d39-905e-4b12-8d0d-258ca48b56ff" />
<img width="120" height="74" alt="image" src="https://github.com/user-attachments/assets/0f235029-36ff-412c-a28d-4bbb13a0a50a" />

This pull request simply adds a check to see if the afflictions have already been displayed. If so then don't display again.