### PR TITLE
Add bot first aid AI compatibility

### DIFF
--- a/Neurotrauma/Credits.txt
+++ b/Neurotrauma/Credits.txt
@@ -1,4 +1,3 @@
-
 Evil Factory - Lua help
 I only use this when bored - Better scanner code and contributions to config GUI
 Luka - Config GUI contributions
@@ -22,3 +21,4 @@ Oskar - Spanish localization
 mefy - Turkish localization
 profole - German localization
 Liatoast - Further improvements to German localization
+Dahaka - Bot AI first aid compatibility

--- a/Neurotrauma/Localization/Portuguese/Portuguese.xml
+++ b/Neurotrauma/Localization/Portuguese/Portuguese.xml
@@ -8,7 +8,7 @@
 <entityname.aed>Desfibrilador Externo Automático</entityname.aed>
 <entitydescription.aed>Um dispositivo médico que aplica um choque elétrico ao coração para estabilizar as arritmias cardíacas. Requer pouco treinamento médico. Use em um paciente com parada cardíaca.</entitydescription.aed>
 <entityname.bvm>Ressuscitador AMBU</entityname.bvm>
-<entitydescription.bvm>Uma bolsa-válvula-máscara, é um disputivo portátil comumente usado para fornecer ventilação para pacientes que não estão respirando ou não estão respirando adequadamente.</entitydescription.bvm>
+<entitydescription.bvm>Uma bolsa-válvula-máscara, é um dispositivo portátil comumente usado para fornecer ventilação para pacientes que não estão respirando ou não estão respirando adequadamente.</entitydescription.bvm>
 <entityname.autocpr>AutoPulse</entityname.autocpr>
 <entitydescription.autocpr>Um dispositivo de ressuscitação cardiopulmonar automatizado, portátil e alimentado por bateria.</entitydescription.autocpr>
 <entityname.bloodanalyzer>Analisador Hematológico</entityname.bloodanalyzer>
@@ -18,7 +18,7 @@
 <entityname.traumashears>Tesouras Médicas</entityname.traumashears>
 <entitydescription.traumashears>Uma ferramenta usada para remover bandagens e gessos.</entitydescription.traumashears>
 <entityname.wheelchair>Cadeira de Rodas</entityname.wheelchair>
-<entitydescription.wheelchair>Faz você depender de seus braços ao invés de suas pernas para a movimentação.</entitydescription.wheelchair>
+<entitydescription.wheelchair>Faz você depender de seus braços em vez de suas pernas para a movimentação.</entitydescription.wheelchair>
 <entityname.blahaj>Tubarão Azul</entityname.blahaj>
 
 <entityname.healthscanner>Visor de Saúde</entityname.healthscanner>
@@ -56,24 +56,6 @@
 <entitydescription.organscalpel_heart>Um bisturi especializado para a remoção do coração.</entitydescription.organscalpel_heart>
 <entityname.organscalpel_brain>Bisturi para Aquisição de Órgãos: Cérebro</entityname.organscalpel_brain>
 <entitydescription.organscalpel_brain>Um bisturi especializado para a remoção do cérebro.</entitydescription.organscalpel_brain>
-<!--<entityname.multiscalpel>Multipurpose scalpel</entityname.multiscalpel>
-<entitydescription.multiscalpel>A scalpel you can choose what to do with, be it make an incision, extract organs, remove bandages, or do malpractice.</entitydescription.multiscalpel>
-<multiscalpel.incision>Mode: Surgery incision</multiscalpel.incision>
-<multiscalpel.kidneys>Mode: Extract kidneys</multiscalpel.kidneys>
-<multiscalpel.liver>Mode: Extract liver</multiscalpel.liver>
-<multiscalpel.lungs>Mode: Extract lungs</multiscalpel.lungs>
-<multiscalpel.heart>Mode: Extract heart</multiscalpel.heart>
-<multiscalpel.brain>Mode: Extract brain</multiscalpel.brain>
-<multiscalpel.bandage>Mode: Remove bandages and casts / malpractice</multiscalpel.bandage>
-<multiscalpel.speedflex>Mode: Adaptive organ extraction. Use on head for brain, left arm for kidneys, torso for liver, right arm for heart, left leg for lungs.</multiscalpel.speedflex>
-<multiscalpel.btn.incision>Incision</multiscalpel.btn.incision>
-<multiscalpel.btn.kidneys>Kidneys</multiscalpel.btn.kidneys>
-<multiscalpel.btn.liver>Liver</multiscalpel.btn.liver>
-<multiscalpel.btn.lungs>Lungs</multiscalpel.btn.lungs>
-<multiscalpel.btn.heart>Heart</multiscalpel.btn.heart>
-<multiscalpel.btn.brain>Brain</multiscalpel.btn.brain>
-<multiscalpel.btn.bandage>Bandages, casts, malpractice</multiscalpel.btn.bandage>
-<multiscalpel.btn.speedflex>Adaptive organ extraction</multiscalpel.btn.speedflex>-->
 <!-- /// Treatments /// -->
 <entityname.mannitol>Manitol</entityname.mannitol>
 <entitydescription.mannitol>Um tipo de álcool de açúcar. É usado para ajudar na recuperação de neurotrauma. Pode causar danos aos órgãos.</entitydescription.mannitol>
@@ -91,11 +73,11 @@
 <entitydescription.medstent>Um tubo de plástico inserido na aorta depois do balão endovascular após uma ruptura da aorta.</entitydescription.medstent>
 <entityname.tourniquet>Torniquete</entityname.tourniquet>
 <entitydescription.tourniquet>Um dispositivo que aplica pressão a um membro e, assim, reduz o fluxo sanguíneo. Geralmente é usado em caso de grandes sangramentos nas extremidades. Não deve ser usado na cabeça.</entitydescription.tourniquet>
-<entityname.drainage>Drenaguem Torácica</entityname.drainage>
+<entityname.drainage>Drenagem Torácica</entityname.drainage>
 <entitydescription.drainage>Drena o ar da cavidade pleural durante a cirurgia corretiva de pneumotórax.</entitydescription.drainage>
 <entityname.needle>Agulha</entityname.needle>
 <entitydescription.needle>Uma agulha com uma válvula de descompressão para drenar o ar ou o líquido da cavidade pleural ou do pericárdio.</entitydescription.needle>
-<entityname.ringerssolution>Soluto de Ringer</entityname.ringerssolution>
+<entityname.ringerssolution>Solução de Ringer</entityname.ringerssolution>
 <entitydescription.ringerssolution>Uma solução de vários sais dissolvidos em água com a finalidade de tratar a pressão arterial baixa ou a perda de líquidos. Isotônico ao sangue.</entitydescription.ringerssolution>
 <entityname.antiseptic>Antisséptico</entityname.antiseptic>
 <!-- <entitydescription.antiseptic></entitydescription.antiseptic> -->
@@ -116,7 +98,7 @@
 <entitydescription.bloodpackoplus>Administrado para: O+, A+, B+, AB+</entitydescription.bloodpackoplus>
 <entityname.bloodpackominus>Bolsa de Sangue O-</entityname.bloodpackominus>
 <entitydescription.bloodpackominus>Um pacote de sangue que pode ser usado em qualquer paciente.</entitydescription.bloodpackominus>
-<entityname.bloodpackaplus>Bolsa de Sanguek A+</entityname.bloodpackaplus>
+<entityname.bloodpackaplus>Bolsa de Sangue A+</entityname.bloodpackaplus>
 <entitydescription.bloodpackaplus>Administrado para: A+, AB+</entitydescription.bloodpackaplus>
 <entityname.bloodpackbplus>Bolsa de Sangue B+</entityname.bloodpackbplus>
 <entitydescription.bloodpackbplus>Administrado para: B+, AB+</entitydescription.bloodpackbplus>
@@ -230,31 +212,31 @@ Pode dar sangue para: AB+</entitydescription.abpluscard>
 <afflictionname.cardiacarrest>Parada Cardíaca</afflictionname.cardiacarrest>
 <afflictiondescription.cardiacarrest>Sem pulso.</afflictiondescription.cardiacarrest>
 <afflictionname.heartattack>Ataque Cardíaco</afflictionname.heartattack>
-<afflictiondescription.heartattack></afflictiondescription.heartattack>
+<afflictiondescription.heartattack>O fluxo sanguíneo para o coração está comprometido.</afflictiondescription.heartattack>
 <afflictionname.heartdamage>Dano no Coração</afflictionname.heartdamage>
-<afflictiondescription.heartdamage></afflictiondescription.heartdamage>
+<afflictiondescription.heartdamage>O coração sofreu dano e está funcionando pior.</afflictiondescription.heartdamage>
 <afflictionname.heartfailure>Insuficiência Cardíaca</afflictionname.heartfailure>
-<afflictiondescription.heartfailure></afflictiondescription.heartfailure>
+<afflictiondescription.heartfailure>O coração não consegue bombear sangue adequadamente.</afflictiondescription.heartfailure>
 <afflictionname.heartremoved>Coração Removido</afflictionname.heartremoved>
 <afflictiondescription.heartremoved>O coração foi removido cirurgicamente.</afflictiondescription.heartremoved>
 <!-- /// Brain /// -->
 <afflictionname.cerebralhypoxia>Neurotrauma</afflictionname.cerebralhypoxia>
-<afflictiondescription.cerebralhypoxia></afflictiondescription.cerebralhypoxia>
+<afflictiondescription.cerebralhypoxia>O cérebro não está recebendo oxigênio suficiente.</afflictiondescription.cerebralhypoxia>
 <afflictioncauseofdeath.cerebralhypoxia>Morte por neurotrauma.</afflictioncauseofdeath.cerebralhypoxia>
 <afflictioncauseofdeathself.cerebralhypoxia>Você morreu de neurotrauma.</afflictioncauseofdeathself.cerebralhypoxia>
 <afflictionname.stroke>Derrame</afflictionname.stroke>
-<afflictiondescription.stroke></afflictiondescription.stroke>
+<afflictiondescription.stroke>O fluxo sanguíneo cerebral foi interrompido ou prejudicado.</afflictiondescription.stroke>
 <afflictionname.seizure>Convulsão</afflictionname.seizure>
-<afflictiondescription.seizure></afflictiondescription.seizure>
+<afflictiondescription.seizure>O paciente está sofrendo atividade neurológica anormal e convulsiva.</afflictiondescription.seizure>
 <afflictionname.coma>Coma</afflictionname.coma>
-<afflictiondescription.coma></afflictiondescription.coma>
+<afflictiondescription.coma>O paciente está em um estado prolongado de inconsciência profunda.</afflictiondescription.coma>
 <afflictionname.brainremoved>Cérebro Removido</afflictionname.brainremoved>
 <afflictiondescription.brainremoved>O cérebro foi removido cirurgicamente.</afflictiondescription.brainremoved>
 <!-- /// Blood /// -->
 <afflictionname.bloodpressure>Pressão Sanguínea</afflictionname.bloodpressure>
-<afflictiondescription.bloodpressure></afflictiondescription.bloodpressure>
+<afflictiondescription.bloodpressure>Representa a pressão atual do sangue do paciente.</afflictiondescription.bloodpressure>
 <afflictionname.hypoxemia>Hipoxemia</afflictionname.hypoxemia>
-<afflictiondescription.hypoxemia></afflictiondescription.hypoxemia>
+<afflictiondescription.hypoxemia>O sangue está com pouco oxigênio.</afflictiondescription.hypoxemia>
 <!-- /// Lungs /// -->
 <afflictionname.respiratoryarrest>Parada Respiratória</afflictionname.respiratoryarrest>
 <afflictiondescription.respiratoryarrest>O paciente não está respirando.</afflictiondescription.respiratoryarrest>
@@ -265,45 +247,41 @@ Pode dar sangue para: AB+</entitydescription.abpluscard>
 <afflictionname.dyspnea>Falta de Ar</afflictionname.dyspnea>
 <afflictiondescription.dyspnea>A respiração do paciente é difícil e fraca.</afflictiondescription.dyspnea>
 <afflictionname.alkalosis>Alcalose</afflictionname.alkalosis>
-<afflictiondescription.alkalosis></afflictiondescription.alkalosis>
+<afflictiondescription.alkalosis>O sangue está alcalino demais.</afflictiondescription.alkalosis>
 <afflictionname.acidosis>Acidose</afflictionname.acidosis>
-<afflictiondescription.acidosis></afflictiondescription.acidosis>
+<afflictiondescription.acidosis>O sangue está ácido demais.</afflictiondescription.acidosis>
 <afflictionname.rili>Lesão Pulmonar induzida por Radiação</afflictionname.rili>
-<afflictiondescription.rili></afflictiondescription.rili>
+<afflictiondescription.rili>Os pulmões foram danificados por radiação.</afflictiondescription.rili>
 <afflictionname.pneumothorax>Pneumotórax</afflictionname.pneumothorax>
-<afflictiondescription.pneumothorax></afflictiondescription.pneumothorax>
+<afflictiondescription.pneumothorax>Há ar acumulado na cavidade pleural, prejudicando a respiração.</afflictiondescription.pneumothorax>
 <afflictionname.lungdamage>Dano nos Pulmões</afflictionname.lungdamage>
-<afflictiondescription.lungdamage></afflictiondescription.lungdamage>
+<afflictiondescription.lungdamage>Os pulmões sofreram dano e estão funcionando pior.</afflictiondescription.lungdamage>
 <afflictionname.lungfailure>Insuficiência Pulmonar</afflictionname.lungfailure>
-<afflictiondescription.lungfailure></afflictiondescription.lungfailure>
+<afflictiondescription.lungfailure>Os pulmões não conseguem realizar trocas gasosas adequadamente.</afflictiondescription.lungfailure>
 <afflictionname.lungremoved>Pulmões Removidos</afflictionname.lungremoved>
 <afflictiondescription.lungremoved>Os pulmões foram removidos cirurgicamente.</afflictiondescription.lungremoved>
 <!-- /// kidneys /// -->
 <afflictionname.kidneydamage>Dano nos Rins</afflictionname.kidneydamage>
-<afflictiondescription.kidneydamage></afflictiondescription.kidneydamage>
+<afflictiondescription.kidneydamage>Os rins sofreram dano e estão filtrando pior o sangue.</afflictiondescription.kidneydamage>
 <afflictionname.kidneyfailure>Falência Renal</afflictionname.kidneyfailure>
-<afflictiondescription.kidneyfailure></afflictiondescription.kidneyfailure>
+<afflictiondescription.kidneyfailure>Os rins falharam e não conseguem filtrar o sangue adequadamente.</afflictiondescription.kidneyfailure>
 <afflictionname.kidneyremoved>Rins Removidos</afflictionname.kidneyremoved>
 <afflictiondescription.kidneyremoved>Os rins foram removidos cirurgicamente.</afflictiondescription.kidneyremoved>
 <!-- /// bones /// -->
 <afflictionname.bonedamage>Dano Ósseo</afflictionname.bonedamage>
-<afflictiondescription.bone></afflictiondescription.bone>
+<afflictiondescription.bone>O osso sofreu dano.</afflictiondescription.bone>
 <afflictionname.bonedeath>Morte Óssea</afflictionname.bonedeath>
-<afflictiondescription.bonedeath></afflictiondescription.bonedeath>
+<afflictiondescription.bonedeath>O tecido ósseo morreu e não está se recuperando.</afflictiondescription.bonedeath>
 <afflictionname.bonegrowth>Crescimento Ósseo Estimulado</afflictionname.bonegrowth>
 <afflictiondescription.bonegrowth>O crescimento ósseo foi estimulado. Para curar a morte óssea, essa aflição precisa estar em todas as partes do corpo.</afflictiondescription.bonegrowth>
 <!-- /// liver /// -->
 <afflictionname.liverdamage>Dano no Fígado</afflictionname.liverdamage>
-<afflictiondescription.liverdamage></afflictiondescription.liverdamage>
+<afflictiondescription.liverdamage>O fígado sofreu dano e está funcionando pior.</afflictiondescription.liverdamage>
 <afflictionname.liverfailure>Insuficiência Hepática</afflictionname.liverfailure>
-<afflictiondescription.liverfailure></afflictiondescription.liverfailure>
+<afflictiondescription.liverfailure>O fígado falhou e não consegue manter suas funções vitais.</afflictiondescription.liverfailure>
 <afflictionname.liverremoved>Fígado Removido</afflictionname.liverremoved>
 <afflictiondescription.liverremoved>O fígado foi removido cirurgicamente.</afflictiondescription.liverremoved>
 <!-- /// surgery and related /// -->
-<afflictionname.surgeryincision>Incisão Cirúrgica</afflictionname.surgeryincision>
-<afflictiondescription.surgeryincision>Uma incisão foi feita por um bisturi.</afflictiondescription.surgeryincision>
-<afflictionname.clampedbleeders>Sangamentro Estancado</afflictionname.clampedbleeders>
-<afflictiondescription.clampedbleeders>Sangramentos cirúrgicos foram estancados.</afflictiondescription.clampedbleeders>
 <afflictionname.arteriesclamp>Artéria Bloqueada por Balão</afflictionname.arteriesclamp>
 <afflictiondescription.arteriesclamp>O sangramento da artéria foi interrompido, mas o fluxo sanguíneo para a extremidade está severamente reduzido.</afflictiondescription.arteriesclamp>
 <afflictionname.balloonedaorta>Aorta Bloqueada por Balão</afflictionname.balloonedaorta>
@@ -383,41 +361,41 @@ Pode dar sangue para: AB+</entitydescription.abpluscard>
 <afflictionname.suturedw>Ferida Suturada</afflictionname.suturedw>
 <afflictiondescription.suturedw>As feridas foram suturadas.</afflictiondescription.suturedw>
 <afflictionname.immunity>Imunidade</afflictionname.immunity>
-<afflictiondescription.immunity></afflictiondescription.immunity>
+<afflictiondescription.immunity>Representa a resistência do organismo contra infecções e rejeições.</afflictiondescription.immunity>
 <afflictionname.infectedwound>Ferida Infectada</afflictionname.infectedwound>
-<afflictiondescription.infectedwound></afflictiondescription.infectedwound>
+<afflictiondescription.infectedwound>A ferida está infectada e pode piorar se não for tratada.</afflictiondescription.infectedwound>
 <afflictionname.sepsis>Infeção Sanguínea</afflictionname.sepsis>
-<afflictiondescription.sepsis></afflictiondescription.sepsis>
+<afflictiondescription.sepsis>Uma infecção sistêmica grave está se espalhando pelo sangue.</afflictiondescription.sepsis>
 <afflictionname.necrosis>Necrose</afflictionname.necrosis>
-<afflictiondescription.necrosis></afflictiondescription.necrosis>
+<afflictiondescription.necrosis>O tecido morreu e pode levar a complicações graves.</afflictiondescription.necrosis>
 <afflictioncauseofdeath.necrosis>Morreu de uma ferida necrótica.</afflictioncauseofdeath.necrosis>
 <afflictioncauseofdeathself.necrosis>Você morreu de necrose.</afflictioncauseofdeathself.necrosis>
 <afflictionname.gangrene>Gangrena</afflictionname.gangrene>
 <afflictiondescription.gangrene>A extremidade encolheu e se tornou preta.</afflictiondescription.gangrene>
 <afflictionname.afadrenaline>Adrenalina</afflictionname.afadrenaline>
-<afflictiondescription.afadrenaline></afflictiondescription.afadrenaline>
+<afflictiondescription.afadrenaline>Adrenalina ativa no organismo.</afflictiondescription.afadrenaline>
 <afflictionname.afstreptokinase>Anti-Coágulo</afflictionname.afstreptokinase>
-<afflictiondescription.afstreptokinase></afflictiondescription.afstreptokinase>
+<afflictiondescription.afstreptokinase>Estreptoquinase ativa no organismo, reduzindo coágulos.</afflictiondescription.afstreptokinase>
 <afflictionname.afthiamine>Tiamina</afflictionname.afthiamine>
-<afflictiondescription.afthiamine></afflictiondescription.afthiamine>
+<afflictiondescription.afthiamine>Tiamina ativa no organismo.</afflictiondescription.afthiamine>
 <afflictionname.afsaline>Soro Fisiológico</afflictionname.afsaline>
-<afflictiondescription.afsaline></afflictiondescription.afsaline>
+<afflictiondescription.afsaline>Soro fisiológico ativo no organismo.</afflictiondescription.afsaline>
 <afflictionname.afringerssolution>Solução de Ringer</afflictionname.afringerssolution>
-<afflictiondescription.afringerssolution></afflictiondescription.afringerssolution>
+<afflictiondescription.afringerssolution>Solução de Ringer ativa no organismo.</afflictiondescription.afringerssolution>
 <afflictionname.afmannitol>Manitol</afflictionname.afmannitol>
-<afflictiondescription.afmannitol></afflictiondescription.afmannitol>
+<afflictiondescription.afmannitol>Manitol ativo no organismo.</afflictiondescription.afmannitol>
 <afflictionname.afantibiotics>Antibióticos</afflictionname.afantibiotics>
-<afflictiondescription.afantibiotics></afflictiondescription.afantibiotics>
+<afflictiondescription.afantibiotics>Antibióticos ativos no organismo.</afflictiondescription.afantibiotics>
 <afflictionname.afimmunosuppressant>Imunossupressores</afflictionname.afimmunosuppressant>
-<afflictiondescription.afimmunosuppressant></afflictiondescription.afimmunosuppressant>
+<afflictiondescription.afimmunosuppressant>Imunossupressores ativos no organismo.</afflictiondescription.afimmunosuppressant>
 <afflictionname.hemotransfusionshock>Choque de Hemotransfusão</afflictionname.hemotransfusionshock>
-<afflictiondescription.hemotransfusionshock></afflictiondescription.hemotransfusionshock>
+<afflictiondescription.hemotransfusionshock>O paciente está reagindo mal a uma transfusão incompatível.</afflictiondescription.hemotransfusionshock>
 <afflictionname.foreignbody>Corpo Estranho</afflictionname.foreignbody>
-<afflictiondescription.foreignbody></afflictiondescription.foreignbody>
+<afflictiondescription.foreignbody>Há uma bala, estilhaço ou outro corpo estranho alojado no tecido.</afflictiondescription.foreignbody>
 <afflictionname.tamponade>Tamponamento Cardíaco</afflictionname.tamponade>
-<afflictiondescription.tamponade></afflictiondescription.tamponade>
+<afflictiondescription.tamponade>Fluido ou sangue está comprimindo o coração e prejudicando seu funcionamento.</afflictiondescription.tamponade>
 <afflictionname.internalbleeding>Sangramento Interno</afflictionname.internalbleeding>
-<afflictiondescription.internalbleeding></afflictiondescription.internalbleeding>
+<afflictiondescription.internalbleeding>Há sangramento dentro do corpo.</afflictiondescription.internalbleeding>
 <!-- /// symptoms /// -->
 <afflictionname.sym_cough>Tosse</afflictionname.sym_cough>
 <afflictiondescription.sym_cough>O paciente está tossindo periodicamente.</afflictiondescription.sym_cough>
@@ -514,6 +492,176 @@ Pode dar sangue para: AB+</entitydescription.abpluscard>
 <connection.bloodphout>Blood_pH</connection.bloodphout>
 <!-- misc -->
 <roomname.surgical>Sala de Cirurgia</roomname.surgical>
+
+<!-- Traduções complementares -->
+<entityname.analgesictank>Tanque de Analgésico</entityname.analgesictank>
+<entitydescription.analgesictank>Um tanque de analgésicos gasosos que pode ser instalado em uma mesa cirúrgica ou usado em um AMBU.</entitydescription.analgesictank>
+<entityname.anesthetictank>Tanque de Anestésico</entityname.anesthetictank>
+<entitydescription.anesthetictank>Um tanque de anestésicos gasosos que pode ser instalado em uma mesa cirúrgica ou usado em um AMBU.</entitydescription.anesthetictank>
+<entityname.dialyzer>Filtro de Diálise</entityname.dialyzer>
+<entitydescription.dialyzer>Um filtro avançado que pode ser instalado em uma mesa cirúrgica para combater alcalose e acidose.</entitydescription.dialyzer>
+<entityname.toxfilter>Filtro de Toxinas</entityname.toxfilter>
+<entitydescription.toxfilter>Um filtro avançado que pode ser instalado em uma mesa cirúrgica para ajudar a remover venenos da corrente sanguínea.</entitydescription.toxfilter>
+<itemmsgmodifytable>[[attack]] Interagir</itemmsgmodifytable>
+<operatingtabellabel>Melhorias da Mesa Cirúrgica</operatingtabellabel>
+
+<entityname.multiscalpel>Bisturi multiuso</entityname.multiscalpel>
+<entitydescription.multiscalpel>Bisturi experimental. Desativado e precisa ser ativado. Nas mãos do profissional, um painel de botões pode ativar o bisturi e alternar entre operações: fazer incisões, extrair órgãos, remover bandagens ou cometer negligência médica.</entitydescription.multiscalpel>
+<multiscalpel.incision>Modo ativo: incisão cirúrgica</multiscalpel.incision>
+<multiscalpel.kidneys>Modo ativo: extrair rins</multiscalpel.kidneys>
+<multiscalpel.liver>Modo ativo: extrair fígado</multiscalpel.liver>
+<multiscalpel.lungs>Modo ativo: extrair pulmões</multiscalpel.lungs>
+<multiscalpel.heart>Modo ativo: extrair coração</multiscalpel.heart>
+<multiscalpel.brain>Modo ativo: extrair cérebro</multiscalpel.brain>
+<multiscalpel.bandage>Modo ativo: remover bandagens e gessos / negligência médica</multiscalpel.bandage>
+<multiscalpel.speedflex>Modo ativo: extração adaptativa de órgãos. Use na cabeça para cérebro, braço esquerdo para rins, torso para fígado, braço direito para coração e perna esquerda para pulmões.</multiscalpel.speedflex>
+<multiscalpel.btn.incision>Incisão</multiscalpel.btn.incision>
+<multiscalpel.btn.kidneys>Rins</multiscalpel.btn.kidneys>
+<multiscalpel.btn.liver>Fígado</multiscalpel.btn.liver>
+<multiscalpel.btn.lungs>Pulmões</multiscalpel.btn.lungs>
+<multiscalpel.btn.heart>Coração</multiscalpel.btn.heart>
+<multiscalpel.btn.brain>Cérebro</multiscalpel.btn.brain>
+<multiscalpel.btn.bandage>Bandagens, gessos, negligência</multiscalpel.btn.bandage>
+<multiscalpel.btn.speedflex>Extração adaptativa de órgãos</multiscalpel.btn.speedflex>
+
+<entityname.pressuremeds>Nitroprussiato de sódio</entityname.pressuremeds>
+<entitydescription.pressuremeds>Um medicamento usado para reduzir a pressão arterial.</entitydescription.pressuremeds>
+<entityname.skinaid>Pomada regenerativa</entityname.skinaid>
+<entitydescription.skinaid>Um gel regenerativo potente que promove a cura natural da maior parte dos traumas superficiais.</entitydescription.skinaid>
+<entityname.gelipack>Bolsa de gel refrigerante</entityname.gelipack>
+<entitydescription.gelipack>Uma bolsa refrigerante reutilizável cheia de gel orgânico que nunca vence. Perde efetividade sem refrigeração.</entitydescription.gelipack>
+<entitydescription.antiseptic>Pode ser usado para desinfetar feridas com um pulverizador antisséptico.</entitydescription.antiseptic>
+<entitydescription.antisepticspray>Usado para aplicar antisséptico em feridas infectadas.</entitydescription.antisepticspray>
+
+<displayname.surgerysetscalpel>[itemname] (kit, bisturis de órgãos)</displayname.surgerysetscalpel>
+<entityname.medstartercrate>Caixa médica inicial</entityname.medstartercrate>
+<entitydescription.medstartercrate>Uma caixa que contém todos os itens essenciais, convenientemente reunidos em uma única receita de fabricação.</entitydescription.medstartercrate>
+<entityname.headta>Restos de cabeça</entityname.headta>
+<entitydescription.headta>Uma cabeça decepada, ou o que restou dela.</entitydescription.headta>
+<entityname.headsa>Cabeça amputada</entityname.headsa>
+<entitydescription.headsa>Uma cabeça decepada para reciclagem.</entitydescription.headsa>
+<ItemMsgPutInsideSelectKey>[[select]] Colocar dentro</ItemMsgPutInsideSelectKey>
+<ItemMsgTakeOutSelectKey>[[select]] Retirar</ItemMsgTakeOutSelectKey>
+
+<afflictionname.brainswap>Substituindo cérebro</afflictionname.brainswap>
+<afflictiondescription.brainswap>O cérebro antigo foi preparado cirurgicamente para um novo transplante.</afflictiondescription.brainswap>
+<afflictionname.heartswap>Substituindo coração</afflictionname.heartswap>
+<afflictiondescription.heartswap>O coração antigo foi preparado cirurgicamente para um novo transplante.</afflictiondescription.heartswap>
+<afflictionname.kidneyswap>Substituindo rins</afflictionname.kidneyswap>
+<afflictiondescription.kidneyswap>Os rins antigos foram preparados cirurgicamente para um novo transplante.</afflictiondescription.kidneyswap>
+<afflictionname.liverswap>Substituindo fígado</afflictionname.liverswap>
+<afflictiondescription.liverswap>O fígado antigo foi preparado cirurgicamente para um novo transplante.</afflictiondescription.liverswap>
+<afflictionname.lungswap>Substituindo pulmões</afflictionname.lungswap>
+<afflictiondescription.lungswap>Os pulmões antigos foram preparados cirurgicamente para um novo transplante.</afflictiondescription.lungswap>
+<afflictionname.iced>Resfriado</afflictionname.iced>
+<afflictiondescription.iced>Cura contusões. O movimento fica mais lento.</afflictiondescription.iced>
+<afflictionname.skinointmented>Pomada regenerativa</afflictionname.skinointmented>
+<afflictiondescription.skinointmented>Uma camada de gel regenerativo acelera a cura de queimaduras e trauma contundente.</afflictiondescription.skinointmented>
+<afflictionname.tshocktimeout>Imunidade a choque traumático</afflictionname.tshocktimeout>
+<afflictiondescription.tshocktimeout>O paciente foi deixado sem supervisão; por algum tempo ele não perceberá que foi aberto.</afflictiondescription.tshocktimeout>
+<afflictionname.modconflict>Conflito de mod</afflictionname.modconflict>
+<afflictiondescription.modconflict>Há um conflito de mod. Outro mod está sobrescrevendo alguns dos mesmos itens que o Neurotrauma altera. Algumas coisas podem não funcionar corretamente. Ajuste a ordem de carregamento.</afflictiondescription.modconflict>
+<afflictionname.afanaesthetic>Anestésicos</afflictionname.afanaesthetic>
+<afflictiondescription.afanaesthetic>Anestésicos ativos no organismo.</afflictiondescription.afanaesthetic>
+<afflictionname.afopioid>Opioides</afflictionname.afopioid>
+<afflictiondescription.afopioid>Opioides ativos no organismo.</afflictiondescription.afopioid>
+<afflictionname.afpressuredrug>Redutores de pressão arterial</afflictionname.afpressuredrug>
+<afflictiondescription.afpressuredrug>Medicamentos redutores de pressão arterial ativos no organismo.</afflictiondescription.afpressuredrug>
+
+<talentdescription.itemgiveslessaffliction>Administrar ‖color:gui.orange‖Sangue Alienígena‖end‖ causa [amount]% menos ‖color:gui.orange‖Psicose‖end‖ e ‖color:gui.green‖90%‖end‖ menos ‖color:gui.orange‖Choque de Hemotransfusão‖end‖.</talentdescription.itemgiveslessaffliction>
+
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Pessoal não médico pode tratar parada cardíaca usando adrenalina ou um AutoPulse.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Está pegando fogo? Talvez você esteja mais perto de um traje de mergulho do que do lastro ou de um extintor.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Morfina não serve apenas para cirurgia. Analgesia suficiente aumenta a resistência a dano e atordoamento.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ O AED sempre reinicia a fibrilação, independentemente do treinamento médico.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Drogas ainda podem ser administradas a um paciente em uma bolsa de estase.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Oxygenite líquido previne inconsciência causada por hipoxemia.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Lembre-se de pegar seu membro depois que ele for amputado traumaticamente. Procure-o no cadáver do monstro que o arrancou.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Dano nos rins e no fígado causará neurotrauma. Bons médicos mantêm órgãos sobressalentes por perto.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Para diagnóstico completo, lembre-se de verificar a interface de saúde, o visor de saúde e o analisador hematológico.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Vários sintomas são exclusivos do choque de hemotransfusão.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Se você sofreu dano demais em um membro, ele pode não regenerar mais naturalmente. Bandagens e bolsas de gelo aceleram a regeneração natural, em vez de tratar feridas diretamente.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Você pode administrar um AutoPulse pela interface de saúde para equipá-lo imediatamente no paciente. Usar uma chave inglesa no torso o colocará de volta no seu inventário.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Enfaixar uma fratura no pescoço impede que ela cause lesão na medula espinal.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ O AutoPulse é sempre melhor que CPR, e os dois não acumulam.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Hipoxemia significa oxigênio insuficiente no sangue. Não confunda com hipóxia, também conhecida como oxigênio baixo.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Manitol só trata neurotrauma se a pressão arterial estiver acima de 70% e a hipoxemia abaixo de 30%. Se as condições não forem atendidas, ele desacelera a progressão do neurotrauma.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ A regeneração natural de neurotrauma pode ser mais rápida se o paciente tiver menos de 20% das causas. Mantenha o paciente absolutamente saudável para uma recuperação mais rápida.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Bots às vezes reclamam dos próprios sintomas. Lembre-se de examiná-los regularmente.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Você pode usar pinça através de feridas abertas de tiro ou feridas profundas, mas isso sempre causará um pequeno choque traumático.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Fibrilação é sempre perigosa. A pressão arterial cai muito mais rápido do que sobe.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Concussões nunca são perigosas, mas causam vários sintomas que podem ser confundidos com aflições perigosas.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ O corpo humano sempre rejeitará sangue alienígena, independentemente da força da imunidade.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ A força da imunidade afeta a cura natural de feridas infectadas, rejeição de órgãos e rejeição de tipos sanguíneos incompatíveis.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Se estiver usando o guia do Trello, confirme que está usando a versão para o Community Fork.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Feridas internas, como trauma contundente, não têm risco de infecção.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Sepse só pode ser tratada com antibióticos de amplo espectro. Mantenha alguns por perto.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Camas não médicas só previnem choque traumático se o paciente estiver deitado nelas.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Você pode coletar uma bolsa de sangue por vez de humanos saudáveis, desde que a aplicação seja bem-sucedida.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Para tratar gangrena acima de 15%, é necessário remover o membro e anexar um novo.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ A maioria das chances e taxas de ganho de aflições pode ser configurada. Para encontrar a configuração, abra o menu Esc depois de carregar uma partida. Gritos, comportamento do gesso e rejeição de órgãos também podem ser configurados.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ O preço da maioria dos itens pode ser configurado. Para encontrar a configuração, abra o menu Esc depois de carregar uma partida e selecione a aba "Preços de itens" no canto superior esquerdo. Alguns custos de uso e disponibilidade de itens também podem ser configurados.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ É possível, mas mentalmente exigente, jogar sem visor de saúde ou analisador hematológico. A maioria das aflições pode ser diagnosticada por contexto, sintomas e efeitos visuais.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Luxações são extremamente comuns depois de ser pego em uma explosão.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ A chance de ganhar aflições ao ser atingido, como fraturas e tamponamento cardíaco, depende do dano recebido. Se você receber menos dano, precisará de menos tratamento.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Com pouco gesso? Membros e humanos podem ser desconstruídos em cálcio.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Abstinência de drogas nunca é letal, mas abstinência alcoólica severa pode ser perigosa.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Dano no coração e nos pulmões não é letal até chegar a 100%.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Mantenha um tubarão azul por perto. Você nunca sabe quando pode precisar dele.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Alguns sintomas se sobrepõem. Você não consegue ouvir palpitações se o coração não está batendo.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ No Neurotrauma, sua cabeça recebe mais dano, mas seus braços e pernas recebem menos.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Se quiser remover um órgão em vez de substituí-lo, use o bisturi multiuso duas vezes.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Tente não serrar acidentalmente a cabeça do paciente. Se isso acontecer, médicos de posto avançado podem desfazer ossos serrados.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Enfaixar uma luxação ou fratura no braço impede que ela trave sua mão, e enfaixar uma luxação na perna restaura a velocidade de movimento.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Evite usar armas se tiver luxação ou fratura no braço.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Enfaixar uma fratura no braço impede que ela trave sua mão com o tempo.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Você pode forçar um paciente inconsciente a ir para uma mesa cirúrgica para usar o filtro instalado nela.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Lembre-se de tratar as condições subjacentes, não os sintomas. Sintomas servem como método de diagnóstico.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ O submarino não começa com suprimentos médicos suficientes? Verifique se há um armário médico marcado corretamente e se o submarino não está equipado manualmente.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ A velocidade da cirurgia é afetada pela habilidade relevante. Médicos ou cirurgiões melhores operam mais rápido.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Membros biônicos não apodrecem fora da geladeira, mas no restante são idênticos aos biológicos.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ O sangue circula sem parar. Garanta que o paciente tenha sangue suficiente e que o coração esteja funcionando.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ O ar entra e sai. Garanta que o paciente tenha oxigênio suficiente.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ A única cura para coma é o tempo. Manter o paciente com órgãos e sangue saudáveis acelera a recuperação.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Um tripulante distraído pode sofrer queimaduras de terceiro grau antes que você perceba. Estoque plastiseal ou cola antibiótica.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Tente não escanear o paciente com frequência demais. Ele pode receber muita radiação.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Bolsas de estase protegem contra pressão e podem ser usadas para EVA.</loadingscreentip>
+<loadingscreentip>‖color:gui.blue‖Neurotrauma:‖end‖ Se o paciente estiver morrendo rápido demais, ganhe tempo com uma bolsa de estase.</loadingscreentip>
+
+<npcdialogsym.n_fracture>Meu pescoço quebrou!</npcdialogsym.n_fracture>
+<npcdialogsym.h_arterialcut>Estou sangrando pela cabeça!</npcdialogsym.h_arterialcut>
+<npcdialogsym.ll_arterialcut>Minha artéria da perna esquerda foi cortada!</npcdialogsym.ll_arterialcut>
+<npcdialogsym.rl_arterialcut>Minha artéria da perna direita foi cortada!</npcdialogsym.rl_arterialcut>
+<npcdialogsym.ra_arterialcut>Minha artéria do braço direito foi cortada!</npcdialogsym.ra_arterialcut>
+<npcdialogsym.la_arterialcut>Minha artéria do braço esquerdo foi cortada!</npcdialogsym.la_arterialcut>
+<npcdialogsym.sym_hematemesis>Estou vomitando sangue!</npcdialogsym.sym_hematemesis>
+<npcdialogsym.sym_paleskin>Minha pele está ficando pálida!</npcdialogsym.sym_paleskin>
+<npcdialogsym.sym_confusion>Estou me sentindo confuso...</npcdialogsym.sym_confusion>
+<npcdialogsym.sym_lightheadedness>Estou ficando tonto...</npcdialogsym.sym_lightheadedness>
+<npcdialogsym.pain_abdominal>Meu estômago está doendo muito!</npcdialogsym.pain_abdominal>
+<npcdialogsym.inflammation>Estou queimando de inflamação!</npcdialogsym.inflammation>
+<npcdialogsym.gangrene>Alguma coisa está apodrecendo no meu corpo!</npcdialogsym.gangrene>
+<npcdialogsym.fever>Estou com febre alta!</npcdialogsym.fever>
+<npcdialogsym.sym_headache>Minha cabeça está latejando!</npcdialogsym.sym_headache>
+<npcdialogsym.sym_blurredvision>Está tudo embaçado!</npcdialogsym.sym_blurredvision>
+<npcdialogsym.t_fracture>Minhas costelas estão fraturadas!</npcdialogsym.t_fracture>
+<npcdialogsym.h_fracture>Meu crânio quebrou!</npcdialogsym.h_fracture>
+<npcdialogsym.ra_fracture>Meu braço direito quebrou!</npcdialogsym.ra_fracture>
+<npcdialogsym.la_fracture>Meu braço esquerdo quebrou!</npcdialogsym.la_fracture>
+<npcdialogsym.rl_fracture>Minha perna direita quebrou!</npcdialogsym.rl_fracture>
+<npcdialogsym.ll_fracture>Minha perna esquerda quebrou!</npcdialogsym.ll_fracture>
+<npcdialogsym.dislocation1>Minha perna direita está luxada!</npcdialogsym.dislocation1>
+<npcdialogsym.dislocation2>Minha perna esquerda está luxada!</npcdialogsym.dislocation2>
+<npcdialogsym.dislocation3>Meu braço direito está luxado!</npcdialogsym.dislocation3>
+<npcdialogsym.dislocation4>Meu braço esquerdo está luxado!</npcdialogsym.dislocation4>
+<npcdialogsym.pain_chest>Meu peito está doendo!</npcdialogsym.pain_chest>
+<npcdialogsym.sym_weakness>Estou tão fraco...</npcdialogsym.sym_weakness>
+<npcdialogsym.sym_sweating>Estou suando muito!</npcdialogsym.sym_sweating>
+<npcdialogsym.dyspnea>Não consigo respirar direito!</npcdialogsym.dyspnea>
+<npcdialogsym.sym_bloating>Meu estômago está inchado!</npcdialogsym.sym_bloating>
+<npcdialogsym.sym_legswelling>Minha perna está inchando!</npcdialogsym.sym_legswelling>
+<npcdialogsym.sym_craving>Estou com uma fissura intensa!</npcdialogsym.sym_craving>
+<npcdialogsym.sym_palpitations>Meu coração está disparado!</npcdialogsym.sym_palpitations>
 
 <!-- A1.8 -->
 

--- a/Neurotrauma/Lua/Autorun/init.lua
+++ b/Neurotrauma/Lua/Autorun/init.lua
@@ -60,6 +60,8 @@ if (Game.IsMultiplayer and SERVER) or not Game.IsMultiplayer then
 	dofile(NT.Path .. "/Lua/Scripts/Server/fuckbots.lua")
 	dofile(NT.Path .. "/Lua/Scripts/Server/lootcrates.lua")
 	dofile(NT.Path .. "/Lua/Scripts/Server/multiscalpel.lua") -- its important for this to run after items.lua
+	dofile(NT.Path .. "/Lua/Scripts/Server/botfirstaid.lua")
+	dofile(NT.Path .. "/Lua/Scripts/Server/botinitiative.lua")
 	dofile(NT.Path .. "/Lua/Scripts/Server/falldamage.lua")
 	dofile(NT.Path .. "/Lua/Scripts/Server/screams.lua")
 	dofile(NT.Path .. "/Lua/Scripts/Server/modconflict.lua")

--- a/Neurotrauma/Lua/Scripts/Server/botfirstaid.lua
+++ b/Neurotrauma/Lua/Scripts/Server/botfirstaid.lua
@@ -1,0 +1,3107 @@
+﻿if Hook ~= nil and Hook.Remove ~= nil then
+	pcall(function() Hook.Remove("think", "NT.BotFirstAid.Triage") end)
+	pcall(function() Hook.Remove("roundStart", "NT.BotFirstAid.RoundStart") end)
+	pcall(function() Hook.Remove("think", "NT.BotFirstAid.Assist") end)
+	pcall(function() Hook.Remove("roundStart", "NT.BotFirstAid.AssistRoundStart") end)
+end
+
+NT.BotFirstAid = { State = { actionCooldowns = {}, botCooldowns = {}, procedures = {}, itemRequests = {}, itemObjectives = {}, itemFetches = {}, selfCareObjectives = {}, stabilizedCooldowns = {}, cpr = {} } }
+
+local BFA = NT.BotFirstAid
+local HumanAIControllerStatic = nil
+if LuaUserData ~= nil and LuaUserData.CreateStatic ~= nil then
+	pcall(function() HumanAIControllerStatic = LuaUserData.CreateStatic("Barotrauma.HumanAIController", true) end)
+end
+local forbiddenComplexMedicalIdentifiers = {
+	aed = true,
+	autocpr = true,
+	bvm = true,
+	defibrillator = true,
+}
+local AnimControllerAnimation = nil
+if LuaUserData ~= nil then
+	if LuaUserData.CreateEnumTable ~= nil then
+		pcall(function() AnimControllerAnimation = LuaUserData.CreateEnumTable("Barotrauma.AnimController+Animation") end)
+		if AnimControllerAnimation == nil then
+			pcall(function() AnimControllerAnimation = LuaUserData.CreateEnumTable("Barotrauma.AnimController/Animation") end)
+		end
+	end
+	if AnimControllerAnimation == nil and LuaUserData.CreateStatic ~= nil then
+		pcall(function() AnimControllerAnimation = LuaUserData.CreateStatic("Barotrauma.AnimController+Animation", true) end)
+	end
+end
+BFA.Settings = {
+	assistIntervalTicks = 60,
+	maxActionsPerTick = 3,
+	maxOtherTreatmentDistance = 170,
+	maxItemPickupDistance = 120,
+	-- Slightly above one assist interval: smooths bot medical actions without
+	-- slowing life-saving CPR, which explicitly bypasses these cooldowns.
+	actionCooldownTicks = 90,
+	botCooldownTicks = 90,
+	selfBleedingThreshold = 2,
+	selfWoundThreshold = 4,
+	otherBleedingThreshold = 4,
+	otherWoundThreshold = 6,
+	fractureBandageThreshold = 35,
+	dirtyBandageCleanupThreshold = 10,
+	foreignBodyRemovalThreshold = 8,
+	foreignBodyUrgentThreshold = 15,
+	selfCareMinimumScore = 16,
+	selfCareSevereScore = 45,
+	otherCareMinimumScore = 25,
+	nonMedicHelperMinimumScore = 60,
+	quickCareMinimumScore = 45,
+	highSkillMedicalThreshold = 45,
+	missingResourceCooldownTicks = 1800,
+	itemRequestCooldownTicks = 120,
+	itemFetchTimeoutTicks = 5400,
+	itemFetchTargetTimeoutTicks = 1800,
+	stabilizedCooldownTicks = 900,
+}
+
+local function Log(message)
+	if NT ~= nil and NT.TestingEnabled == true then print("[NT BotAid] " .. tostring(message)) end
+end
+
+local function TickCooldowns(tableRef)
+	for key, value in pairs(tableRef) do
+		value = value - BFA.Settings.assistIntervalTicks
+		if value <= 0 then
+			tableRef[key] = nil
+		else
+			tableRef[key] = value
+		end
+	end
+end
+
+local function CharacterKey(character)
+	if character == nil then return "nil" end
+	return tostring(character.ID or character.Name or character)
+end
+
+local function CooldownKey(character, key)
+	return CharacterKey(character) .. ":" .. tostring(key)
+end
+
+local function HasCooldown(tableRef, key)
+	return tableRef[key] ~= nil and tableRef[key] > 0
+end
+
+local function SetCooldown(tableRef, key, ticks)
+	tableRef[key] = ticks
+end
+
+local function SafeProperty(value, propertyName, fallback)
+	if value == nil then return fallback end
+	local ok, result = pcall(function() return value[propertyName] end)
+	if ok then return result end
+	return fallback
+end
+
+local function IsBot(character)
+	if character == nil then return false end
+	local isBot = SafeProperty(character, "IsBot", nil)
+	if isBot ~= nil then return isBot == true end
+	return SafeProperty(character, "AIController", nil) ~= nil and SafeProperty(character, "IsPlayer", false) ~= true
+end
+
+local function IsCrewHuman(character)
+	return character ~= nil
+		and not character.Removed
+		and character.IsHuman
+		and not character.IsDead
+		and (character.TeamID == 1 or character.TeamID == 2)
+end
+
+local function IsMedicalJob(character)
+	local isMedic = SafeProperty(character, "IsMedic", nil)
+	if isMedic ~= nil then return isMedic == true end
+
+	local info = SafeProperty(character, "Info", nil)
+	local job = info ~= nil and SafeProperty(info, "Job", nil) or nil
+	local prefab = job ~= nil and SafeProperty(job, "Prefab", nil) or nil
+	local identifier = prefab ~= nil and SafeProperty(prefab, "Identifier", nil) or nil
+	local value = identifier ~= nil and SafeProperty(identifier, "Value", tostring(identifier)) or ""
+	return value == "medicaldoctor" or value == "doctor" or value == "medic"
+end
+
+local function GetMedicalSkill(character)
+	if HF ~= nil and HF.GetSkillLevel ~= nil then return HF.GetSkillLevel(character, "medical") end
+	return IsMedicalJob(character) and 40 or 10
+end
+
+local function GetAffliction(character, identifier, fallback)
+	if HF ~= nil and HF.GetAfflictionStrength ~= nil then return HF.GetAfflictionStrength(character, identifier, fallback or 0) end
+	return fallback or 0
+end
+
+local function GetAfflictionLimb(character, limbType, identifier, fallback)
+	if HF ~= nil and HF.GetAfflictionStrengthLimb ~= nil then
+		return HF.GetAfflictionStrengthLimb(character, limbType, identifier, fallback or 0)
+	end
+	return fallback or 0
+end
+
+local function AddAffliction(character, identifier, amount, user)
+	if HF ~= nil and HF.AddAffliction ~= nil then HF.AddAffliction(character, identifier, amount, user) end
+end
+
+local function ItemIdentifier(item)
+	if item == nil or item.Prefab == nil or item.Prefab.Identifier == nil then return nil end
+	return item.Prefab.Identifier.Value
+end
+
+local function ItemIdentifierString(item)
+	local identifier = ItemIdentifier(item)
+	if identifier ~= nil then return identifier end
+	if item == nil or item.Prefab == nil or item.Prefab.Identifier == nil then return nil end
+	return tostring(item.Prefab.Identifier)
+end
+
+local function IsDirectlyCarriedBy(character, item)
+	if character == nil or item == nil or character.Inventory == nil then return false end
+	local ok, parentInventory = pcall(function() return item.ParentInventory end)
+	return ok and parentInventory == character.Inventory
+end
+
+local function ParentInventoryOwner(item)
+	if item == nil then return nil end
+	local ok, parentInventory = pcall(function() return item.ParentInventory end)
+	if not ok or parentInventory == nil then return nil end
+
+	local owner = nil
+	pcall(function() owner = parentInventory.Owner end)
+	return owner
+end
+
+local function FetchEntityWorldPosition(entity)
+	if entity == nil then return nil end
+	local position = SafeProperty(entity, "WorldPosition", nil)
+	if position ~= nil then return position end
+	return SafeProperty(entity, "worldPosition", nil)
+end
+
+local function FetchRootInventoryOwner(item)
+	if item == nil then return nil end
+	local owner = nil
+	pcall(function() owner = item.GetRootInventoryOwner() end)
+	if owner ~= nil then return owner end
+	owner = ParentInventoryOwner(item)
+	if owner ~= nil then return owner end
+	return item
+end
+
+local function FetchEntityHull(entity)
+	if entity == nil then return nil end
+	return SafeProperty(entity, "CurrentHull", nil)
+end
+
+local function FetchEntitySubmarine(entity)
+	if entity == nil then return nil end
+	local submarine = SafeProperty(entity, "Submarine", nil)
+	if submarine ~= nil then return submarine end
+
+	local hull = FetchEntityHull(entity)
+	if hull ~= nil then
+		submarine = SafeProperty(hull, "Submarine", nil)
+		if submarine ~= nil then return submarine end
+	end
+
+	return nil
+end
+
+local function FetchItemKey(item)
+	if item == nil then return "nil" end
+	local id = SafeProperty(item, "ID", nil)
+	if id ~= nil then return tostring(id) end
+	return tostring(item)
+end
+
+local function FetchDistanceScore(medic, target)
+	local medicPos = FetchEntityWorldPosition(medic)
+	local targetPos = FetchEntityWorldPosition(target)
+	if medicPos == nil or targetPos == nil or Vector2 == nil then return 100000 end
+
+	local ok, distance = pcall(function() return Vector2.Distance(medicPos, targetPos) end)
+	if ok and type(distance) == "number" then return distance end
+	return 100000
+end
+
+local function FetchCandidateScore(medic, item, rejectedTargets)
+	if item == nil or item.Removed or item.Condition <= 0 then return nil end
+	if rejectedTargets ~= nil and rejectedTargets[FetchItemKey(item)] == true then return nil end
+
+	local owner = ParentInventoryOwner(item)
+	if owner ~= nil and SafeProperty(owner, "IsHuman", false) then return nil end
+
+	local root = FetchRootInventoryOwner(item)
+	if root ~= nil and root ~= item and SafeProperty(root, "IsHuman", false) then return nil end
+
+	local itemHull = FetchEntityHull(item)
+	local rootHull = FetchEntityHull(root)
+	local itemSubmarine = FetchEntitySubmarine(item)
+	local rootSubmarine = FetchEntitySubmarine(root)
+	local targetSubmarine = rootSubmarine or itemSubmarine
+
+	if itemHull == nil and rootHull == nil and targetSubmarine == nil then return nil end
+
+	if medic ~= nil then
+		local medicSubmarine = FetchEntitySubmarine(medic)
+		local medicHull = FetchEntityHull(medic)
+		if medicSubmarine ~= nil and targetSubmarine ~= nil and targetSubmarine ~= medicSubmarine then return nil end
+		if medicSubmarine ~= nil and targetSubmarine == nil and itemHull == nil and rootHull == nil then return nil end
+		if medicHull ~= nil and itemHull == nil and rootHull == nil then return nil end
+	end
+
+	local score = FetchDistanceScore(medic, root or item)
+	local medicHull = FetchEntityHull(medic)
+	local targetHull = rootHull or itemHull
+	if medicHull ~= nil and targetHull ~= nil and medicHull == targetHull then
+		score = score - 5000
+	elseif targetHull == nil then
+		score = score + 5000
+	end
+
+	if root ~= nil and root ~= item then score = score + 150 end
+	return score
+end
+
+local function FindAvailableWorldItem(identifier, medic, rejectedTargets)
+	if Item == nil or Item.ItemList == nil or identifier == nil then return nil end
+
+	local bestItem = nil
+	local bestScore = nil
+	for _, item in pairs(Item.ItemList) do
+		if item ~= nil and not item.Removed and item.Condition > 0 and ItemIdentifierString(item) == identifier then
+			local score = FetchCandidateScore(medic, item, rejectedTargets)
+			if score ~= nil and (bestScore == nil or score < bestScore) then
+				bestItem = item
+				bestScore = score
+			end
+		end
+	end
+
+	return bestItem
+end
+
+local function ItemRequestKey(medic, identifiers)
+	local suffix = ""
+	if type(identifiers) == "table" then
+		for _, identifier in ipairs(identifiers) do
+			suffix = suffix .. tostring(identifier) .. "|"
+		end
+	else
+		suffix = tostring(identifiers)
+	end
+	return CharacterKey(medic) .. ":getitem:" .. suffix
+end
+
+local function ClearMedicalItemFetch(fetchKey)
+	local fetch = BFA.State.itemFetches[fetchKey]
+	if fetch ~= nil and fetch.goTo ~= nil then
+		pcall(function() fetch.goTo.Abandon = true end)
+	end
+	BFA.State.itemFetches[fetchKey] = nil
+	BFA.State.itemObjectives[fetchKey] = nil
+end
+
+local function ClearSelfCareObjective(key)
+	local objective = BFA.State.selfCareObjectives[key]
+	if objective ~= nil then
+		pcall(function() objective.Abandon = true end)
+	end
+	BFA.State.selfCareObjectives[key] = nil
+end
+
+local function ObjectiveIsUsable(objective)
+	if objective == nil then return false end
+	if SafeProperty(objective, "IsCompleted", false) == true then return false end
+	if SafeProperty(objective, "Abandon", false) == true then return false end
+	if SafeProperty(objective, "CanBeCompleted", true) == false then return false end
+	return true
+end
+
+local function SelfCareObjectiveIsUsable(objective)
+	if objective == nil then return false end
+	if SafeProperty(objective, "IsCompleted", false) == true then return false end
+	if SafeProperty(objective, "Abandon", false) == true then return false end
+	return true
+end
+
+local function AddVanillaSelfCareObjective(bot, priorityModifier)
+	if bot == nil or AIObjectiveRescueAll == nil then return false end
+	local ai = SafeProperty(bot, "AIController", nil)
+	local manager = ai ~= nil and SafeProperty(ai, "ObjectiveManager", nil) or nil
+	if manager == nil then return false end
+	local key = CharacterKey(bot)
+
+	local existing = BFA.State.selfCareObjectives[key]
+	if SelfCareObjectiveIsUsable(existing) then
+		pcall(function()
+			existing.ForceHighestPriority = true
+			existing.OverridePriority = 80
+			existing.SpeakIfFails = false
+		end)
+		return true
+	end
+
+	local ok, objective = pcall(function()
+		return AIObjectiveRescueAll(bot, manager, priorityModifier or 1.25)
+	end)
+	if not ok or objective == nil then
+		ok, objective = pcall(function()
+			return AIObjectiveRescueAll.__new(bot, manager, priorityModifier or 1.25)
+		end)
+	end
+	if not ok or objective == nil then return false end
+
+	pcall(function()
+		objective.ForceHighestPriority = true
+		objective.OverridePriority = 80
+		objective.SpeakIfFails = false
+	end)
+
+	local added = pcall(function() manager.AddObjective(objective) end) == true
+	if added then
+		BFA.State.selfCareObjectives[key] = objective
+	end
+	return added
+end
+
+BFA.EnsureSelfCareObjective = AddVanillaSelfCareObjective
+
+local function RequestMedicalItem(medic, identifiers, priorityModifier, useVanillaSelfCare)
+	if medic == nil or medic.Inventory == nil then return false end
+
+	local fetchKey = CharacterKey(medic)
+	if BFA.State.itemFetches[fetchKey] ~= nil then return true end
+
+	local key = ItemRequestKey(medic, identifiers)
+	SetCooldown(BFA.State.itemRequests, key, BFA.Settings.itemRequestCooldownTicks)
+
+	if useVanillaSelfCare == true then AddVanillaSelfCareObjective(medic, 1.25) end
+
+	local selectedIdentifier = nil
+	local selectedItem = nil
+	for _, identifier in ipairs(identifiers) do
+		if not forbiddenComplexMedicalIdentifiers[identifier] then
+			local item = FindAvailableWorldItem(identifier, medic, nil)
+			if item ~= nil then
+				selectedIdentifier = identifier
+				selectedItem = item
+				break
+			end
+		end
+	end
+	if selectedIdentifier == nil then
+		Log(CharacterName(medic) .. " tried to fetch medical item, but no candidate exists on the submarine")
+		return false
+	end
+
+	ClearMedicalItemFetch(fetchKey)
+	pcall(function() medic.DeselectCharacter() end)
+	pcall(function() medic.SelectedCharacter = nil end)
+	BFA.State.itemFetches[fetchKey] = {
+		identifiers = identifiers,
+		selectedIdentifier = selectedIdentifier,
+		targetItem = selectedItem,
+		priorityModifier = priorityModifier or 8,
+		selfCare = useVanillaSelfCare == true,
+		timeout = BFA.Settings.itemFetchTimeoutTicks,
+		targetTimeout = BFA.Settings.itemFetchTargetTimeoutTicks,
+		rejectedTargets = {},
+		takeFailures = 0,
+	}
+	Log(CharacterKey(medic) .. " started physical item fetch for " .. tostring(selectedIdentifier))
+	return true
+end
+
+local function RefreshMedicalItemObjectives()
+	for key, objective in pairs(BFA.State.itemObjectives) do
+		if objective == nil then
+			BFA.State.itemObjectives[key] = nil
+		else
+			local completed = SafeProperty(objective, "IsCompleted", false)
+			local abandoned = SafeProperty(objective, "Abandon", false)
+			local canComplete = SafeProperty(objective, "CanBeCompleted", true)
+			if completed == true or abandoned == true or canComplete == false then
+				BFA.State.itemObjectives[key] = nil
+			else
+				pcall(function() objective.ForceHighestPriority = true end)
+				pcall(function() objective.Priority = 95 end)
+			end
+		end
+	end
+end
+
+local function RefreshSelfCareObjectives()
+	for key, objective in pairs(BFA.State.selfCareObjectives) do
+		if not SelfCareObjectiveIsUsable(objective) then
+			BFA.State.selfCareObjectives[key] = nil
+		else
+			pcall(function()
+				objective.ForceHighestPriority = true
+				objective.OverridePriority = 80
+				objective.SpeakIfFails = false
+			end)
+		end
+	end
+end
+
+local function LimbObject(character, limbType)
+	if character == nil or character.AnimController == nil then return nil end
+	return character.AnimController.GetLimb(limbType or LimbType.Torso)
+end
+
+local function Distance(a, b)
+	if a == nil or b == nil then return 0 end
+	if HF ~= nil and HF.Distance ~= nil then return HF.Distance(a, b) end
+	return Vector2.Distance(a, b)
+end
+
+local limbTypes = {
+	LimbType.Torso,
+	LimbType.Head,
+	LimbType.LeftArm,
+	LimbType.RightArm,
+	LimbType.LeftLeg,
+	LimbType.RightLeg,
+}
+
+local function LimbKey(limbType)
+	if limbType == LimbType.Torso then return "torso" end
+	if limbType == LimbType.Head then return "head" end
+	if limbType == LimbType.LeftArm then return "leftarm" end
+	if limbType == LimbType.RightArm then return "rightarm" end
+	if limbType == LimbType.LeftLeg then return "leftleg" end
+	if limbType == LimbType.RightLeg then return "rightleg" end
+	return tostring(limbType or "unknown")
+end
+
+local function CharacterName(character)
+	return tostring(character ~= nil and (character.Name or character.DisplayName or character.ID) or "unknown")
+end
+
+local function LimbLabel(limbType)
+	if limbType == LimbType.Torso then return "torso" end
+	if limbType == LimbType.Head then return "head" end
+	if limbType == LimbType.LeftArm then return "left arm" end
+	if limbType == LimbType.RightArm then return "right arm" end
+	if limbType == LimbType.LeftLeg then return "left leg" end
+	if limbType == LimbType.RightLeg then return "right leg" end
+	return tostring(limbType or "unknown limb")
+end
+
+local function ItemLabel(identifier)
+	if identifier == "antibleeding1" or identifier == "bandage" then return "bandage" end
+	if identifier == "antibleeding2" then return "plastiseal" end
+	if identifier == "antibleeding3" then return "antibiotic glue" end
+	if identifier == "suture" then return "suture" end
+	if identifier == "gypsum" then return "cast" end
+	if identifier == "tweezers" then return "tweezers" end
+	if identifier == "traumashears" then return "trauma shears" end
+	if identifier ~= nil and HF ~= nil and HF.StartsWith ~= nil and HF.StartsWith(identifier, "divingknife") then return "knife" end
+	if identifier == "wrench" or identifier == "heavywrench" then return "wrench" end
+	if identifier == "screwdriver" then return "screwdriver" end
+	if identifier == "repairpack" then return "repair pack" end
+	if identifier == "antibloodloss2" or identifier == "bloodpackominus" then return "blood bag O-" end
+	if identifier ~= nil and HF ~= nil and HF.StartsWith ~= nil and HF.StartsWith(identifier, "bloodpack") then return "blood bag" end
+	return tostring(identifier or "unknown item")
+end
+
+-- Sequential bot procedures live here. These are treatments that must preserve
+-- a target and execute ordered steps, such as fracture care: bandage, then cast.
+local SequentialProcedures = {}
+
+local function ProcedureKey(medic, patient, procedureName)
+	return CharacterKey(medic) .. ":" .. CharacterKey(patient) .. ":" .. tostring(procedureName)
+end
+
+local function GetProcedureState(medic, patient, procedureName)
+	local key = ProcedureKey(medic, patient, procedureName)
+	local state = BFA.State.procedures[key]
+	if state == nil then
+		state = {}
+		BFA.State.procedures[key] = state
+	end
+	return state
+end
+
+local function ClearProcedureState(medic, patient, procedureName)
+	BFA.State.procedures[ProcedureKey(medic, patient, procedureName)] = nil
+end
+
+local function MissingResourceKey(patient, procedureName, limbType, itemIdentifier)
+	return CharacterKey(patient)
+		.. ":missing:"
+		.. tostring(procedureName)
+		.. ":"
+		.. LimbKey(limbType)
+		.. ":"
+		.. tostring(itemIdentifier)
+end
+
+local function HasMissingResource(patient, procedureName, limbType, itemIdentifier)
+	return HasCooldown(BFA.State.actionCooldowns, MissingResourceKey(patient, procedureName, limbType, itemIdentifier))
+end
+
+local function MarkMissingResource(patient, procedureName, limbType, itemIdentifier)
+	SetCooldown(
+		BFA.State.actionCooldowns,
+		MissingResourceKey(patient, procedureName, limbType, itemIdentifier),
+		BFA.Settings.missingResourceCooldownTicks
+	)
+end
+
+local BloodLossValue
+local NeedsResuscitation
+
+local function LimbIsExtremity(limbType)
+	if HF ~= nil and HF.LimbIsExtremity ~= nil then return HF.LimbIsExtremity(limbType) end
+	return limbType == LimbType.LeftArm
+		or limbType == LimbType.RightArm
+		or limbType == LimbType.LeftLeg
+		or limbType == LimbType.RightLeg
+end
+
+local function LimbIsBroken(patient, limbType)
+	if NT ~= nil and NT.LimbIsBroken ~= nil then return NT.LimbIsBroken(patient, limbType) end
+	return false
+end
+
+local function LimbIsDislocated(patient, limbType)
+	if NT ~= nil and NT.LimbIsDislocated ~= nil then return NT.LimbIsDislocated(patient, limbType) end
+	return false
+end
+
+local function DislocationIdentifier(limbType)
+	if limbType == LimbType.RightLeg then return "dislocation1" end
+	if limbType == LimbType.LeftLeg then return "dislocation2" end
+	if limbType == LimbType.RightArm then return "dislocation3" end
+	if limbType == LimbType.LeftArm then return "dislocation4" end
+	return nil
+end
+
+local function ArterialCutIdentifier(limbType)
+	if limbType == LimbType.Torso then return "t_arterialcut" end
+	if limbType == LimbType.Head then return "h_arterialcut" end
+	if limbType == LimbType.LeftArm then return "la_arterialcut" end
+	if limbType == LimbType.RightArm then return "ra_arterialcut" end
+	if limbType == LimbType.LeftLeg then return "ll_arterialcut" end
+	if limbType == LimbType.RightLeg then return "rl_arterialcut" end
+	return nil
+end
+
+local function GetArterialCut(patient, limbType)
+	local identifier = ArterialCutIdentifier(limbType)
+	if identifier == nil then return 0 end
+
+	local limbValue = GetAfflictionLimb(patient, limbType, identifier, 0)
+	local bodyValue = GetAffliction(patient, identifier, 0)
+	return math.max(limbValue, bodyValue)
+end
+
+local function GetSurgerySkill(medic)
+	if HF ~= nil and HF.GetSurgerySkill ~= nil then
+		local ok, result = pcall(function() return HF.GetSurgerySkill(medic) end)
+		if ok and result ~= nil then return result end
+	end
+	return GetMedicalSkill(medic)
+end
+
+local function HasSurgerySkill(medic, required)
+	if HF ~= nil and HF.GetSurgerySkillRequirementMet ~= nil then
+		local ok, result = pcall(function() return HF.GetSurgerySkillRequirementMet(medic, required) end)
+		if ok then return result == true end
+	end
+	return GetSurgerySkill(medic) >= required
+end
+
+local function DislocationSkillRequired(patient)
+	if GetAffliction(patient, "analgesia", 0) > 0.5 or GetAffliction(patient, "afadrenaline", 0) > 0.5 then
+		return 30
+	end
+	return 60
+end
+
+local function BotCanRelocateDislocation(medic, patient)
+	local medicalSkill = GetMedicalSkill(medic)
+	if IsMedicalJob(medic) then return true end
+	if medicalSkill >= DislocationSkillRequired(patient) then return true end
+	return false
+end
+
+local function FindDislocatedLimb(patient)
+	local bestLimbType = nil
+	local bestScore = 0
+	for _, limbType in ipairs(limbTypes) do
+		if LimbIsExtremity(limbType)
+			and LimbIsDislocated(patient, limbType)
+			and not HasMissingResource(patient, "dislocation", limbType, "relocator")
+		then
+			local score = 100
+				+ GetAfflictionLimb(patient, limbType, "blunttrauma", 0)
+				+ GetAfflictionLimb(patient, limbType, "pain", 0)
+			if score > bestScore then
+				bestScore = score
+				bestLimbType = limbType
+			end
+		end
+	end
+
+	if bestLimbType == nil then return nil, nil end
+	return LimbObject(patient, bestLimbType), bestLimbType
+end
+
+local function FindFractureLimb(patient, needsBandage, preferredLimbKey)
+	local bestLimbType = nil
+	local bestScore = 0
+	for _, limbType in ipairs(limbTypes) do
+		if LimbIsExtremity(limbType)
+			and LimbIsBroken(patient, limbType)
+			and GetAfflictionLimb(patient, limbType, "gypsumcast", 0) <= 0.1
+			and GetAfflictionLimb(patient, limbType, "surgeryincision", 0) <= 1
+			and not HasMissingResource(patient, "fracture_cast", limbType, "gypsum")
+		then
+			local bandaged = GetAfflictionLimb(patient, limbType, "bandaged", 0)
+			local prepared = bandaged >= BFA.Settings.fractureBandageThreshold
+			if prepared ~= needsBandage then
+				local score = 100
+					+ GetAfflictionLimb(patient, limbType, "blunttrauma", 0)
+					+ bandaged
+				if preferredLimbKey ~= nil and LimbKey(limbType) == preferredLimbKey then
+					score = score + 10000
+				end
+				if score > bestScore then
+					bestScore = score
+					bestLimbType = limbType
+				end
+			end
+		end
+	end
+
+	if bestLimbType == nil then return nil, nil end
+	return LimbObject(patient, bestLimbType), bestLimbType
+end
+
+local function FindInventoryItem(character, identifiers)
+	if character == nil or character.Inventory == nil or character.Inventory.AllItems == nil or identifiers == nil then return nil end
+	for item in character.Inventory.AllItems do
+		local identifier = ItemIdentifier(item)
+		if item ~= nil and not item.Removed and item.Condition > 0 and IsDirectlyCarriedBy(character, item) then
+			for _, candidate in ipairs(identifiers) do
+				if identifier == candidate then return item end
+			end
+		end
+	end
+	return nil
+end
+
+local function FindRequestedInventoryItem(character, identifiers)
+	return FindInventoryItem(character, identifiers)
+end
+
+local function IsFetchTargetValid(item)
+	if item == nil or item.Removed or item.Condition <= 0 then return false end
+	local owner = ParentInventoryOwner(item)
+	if owner ~= nil and SafeProperty(owner, "IsHuman", false) then return false end
+	return true
+end
+
+local function RejectFetchTarget(fetch, item, reason)
+	if fetch == nil or item == nil then return end
+	fetch.rejectedTargets = fetch.rejectedTargets or {}
+	fetch.rejectedTargets[FetchItemKey(item)] = true
+	fetch.targetItem = nil
+	fetch.goTo = nil
+	fetch.takeFailures = 0
+	fetch.targetTimeout = BFA.Settings.itemFetchTargetTimeoutTicks
+	Log("rejecting fetch target (" .. tostring(reason or "no reason") .. "): " .. ItemLabel(fetch.selectedIdentifier))
+end
+
+local function RefreshFetchTarget(fetch, medic)
+	if fetch == nil or fetch.identifiers == nil then return nil, nil end
+	if IsFetchTargetValid(fetch.targetItem)
+		and FetchCandidateScore(medic, fetch.targetItem, fetch.rejectedTargets) ~= nil
+	then
+		return fetch.targetItem, fetch.selectedIdentifier
+	end
+
+	for _, identifier in ipairs(fetch.identifiers) do
+		local item = FindAvailableWorldItem(identifier, medic, fetch.rejectedTargets)
+		if item ~= nil then
+			fetch.targetItem = item
+			fetch.selectedIdentifier = identifier
+			fetch.goTo = nil
+			fetch.takeFailures = 0
+			fetch.targetTimeout = BFA.Settings.itemFetchTargetTimeoutTicks
+			return item, identifier
+		end
+	end
+
+	return nil, nil
+end
+
+local function FetchTargetSameHull(medic, item, moveTarget)
+	local medicHull = SafeProperty(medic, "CurrentHull", nil)
+	if medicHull == nil then return true end
+
+	local moveHull = SafeProperty(moveTarget, "CurrentHull", nil)
+	if moveHull ~= nil then return moveHull == medicHull end
+
+	local itemHull = SafeProperty(item, "CurrentHull", nil)
+	if itemHull ~= nil then return itemHull == medicHull end
+
+	return true
+end
+
+local function IsFetchTargetCloseEnough(medic, item, moveTarget)
+	if medic == nil or item == nil then return false end
+	local medicPos = FetchEntityWorldPosition(medic)
+	local targetPos = FetchEntityWorldPosition(moveTarget) or FetchEntityWorldPosition(item)
+	if medicPos == nil or targetPos == nil then return false end
+	if Distance(medicPos, targetPos) > BFA.Settings.maxItemPickupDistance then return false end
+	return FetchTargetSameHull(medic, item, moveTarget)
+end
+
+local function CanInteractWithFetchTarget(medic, item)
+	local moveTarget = FetchRootInventoryOwner(item)
+	if moveTarget == nil then return false, nil end
+	if not IsFetchTargetCloseEnough(medic, item, moveTarget) then return false, moveTarget end
+
+	local canInteract = false
+	if moveTarget == medic then
+		canInteract = true
+	elseif SafeProperty(moveTarget, "IsHuman", false) then
+		pcall(function()
+			medic.SelectCharacter(moveTarget)
+			canInteract = medic.CanInteractWith(moveTarget)
+			medic.DeselectCharacter()
+		end)
+	else
+		pcall(function() canInteract = medic.CanInteractWith(moveTarget, false) end)
+	end
+
+	if not canInteract and moveTarget ~= item then
+		pcall(function() canInteract = medic.CanInteractWith(item, false) end)
+	end
+
+	return canInteract == true, moveTarget
+end
+
+local function TryTakeNearbyItem(medic, item)
+	if medic == nil or medic.Inventory == nil or item == nil then return false end
+
+	local takeItem = nil
+	if HumanAIControllerStatic ~= nil then
+		pcall(function() takeItem = HumanAIControllerStatic.TakeItem end)
+	end
+	if takeItem ~= nil then
+		-- equip into hands
+		local ok, taken = pcall(function()
+			return takeItem(item, medic.Inventory, true, false, true)
+		end)
+		if ok and taken == true then return true end
+
+		-- store without equipping, hands-only slot still
+		ok, taken = pcall(function()
+			return takeItem(item, medic.Inventory, false, false, true)
+		end)
+		if ok and taken == true then return true end
+
+		-- any slot, not hands-only (helps when hands are occupied)
+		ok, taken = pcall(function()
+			return takeItem(item, medic.Inventory, false, false, false)
+		end)
+		if ok and taken == true then return true end
+	end
+
+	local ok, taken = pcall(function()
+		return medic.Inventory.TryPutItem(item, nil, { InvSlotType.Any }, true, true, medic, true, true)
+	end)
+	if ok and taken == true then return true end
+
+	ok, taken = pcall(function()
+		return medic.Inventory.TryPutItem(item, nil, { InvSlotType.Any })
+	end)
+	if ok and taken == true then return true end
+
+	-- Last resort: force-remove the item from its container then retry.
+	-- This generalises the wrench-specific workaround to all medical items that
+	-- may be stuck in a locked container slot (e.g. surgery cabinet, med bag).
+	local parentInventory = nil
+	pcall(function() parentInventory = item.ParentInventory end)
+	if parentInventory ~= nil and parentInventory ~= medic.Inventory then
+		local slot = nil
+		pcall(function() slot = parentInventory.FindIndex(item) end)
+		if slot ~= nil and slot >= 0 then
+			local removed = false
+			pcall(function()
+				parentInventory.ForceRemoveFromSlot(item, slot)
+				removed = true
+			end)
+			if removed then
+				ok, taken = pcall(function()
+					return medic.Inventory.TryPutItem(item, nil, { InvSlotType.Any }, true, true, medic, true, true)
+				end)
+				if ok and taken == true then return true end
+				ok, taken = pcall(function()
+					return medic.Inventory.TryPutItem(item, nil, { InvSlotType.Any })
+				end)
+				if ok and taken == true then return true end
+				-- Failed even after force-remove — put back where it was
+				pcall(function() parentInventory.TryPutItem(item, nil, { slot }, true, true) end)
+			end
+		end
+	end
+
+	return false
+end
+
+local function EnsureFetchGoToObjective(medic, fetch, moveTarget)
+	if medic == nil or fetch == nil or moveTarget == nil or AIObjectiveGoTo == nil then return false end
+	local ai = SafeProperty(medic, "AIController", nil)
+	local manager = ai ~= nil and SafeProperty(ai, "ObjectiveManager", nil) or nil
+	if manager == nil then return false end
+
+	local objective = fetch.goTo
+	if objective ~= nil then
+		local completed = SafeProperty(objective, "IsCompleted", false)
+		local abandoned = SafeProperty(objective, "Abandon", false)
+		local canComplete = SafeProperty(objective, "CanBeCompleted", true)
+		if completed == true or abandoned == true or canComplete == false then
+			fetch.goTo = nil
+		else
+			pcall(function() objective.ForceHighestPriority = true end)
+			pcall(function() objective.OverridePriority = fetch.selfCare and 85 or 95 end)
+			return true
+		end
+	end
+
+	local priorityModifier = fetch.priorityModifier or 8
+	local ok, newObjective = pcall(function()
+		return AIObjectiveGoTo(moveTarget, medic, manager, false, true, priorityModifier, 95)
+	end)
+	if not ok or newObjective == nil then
+		ok, newObjective = pcall(function()
+			return AIObjectiveGoTo.__new(moveTarget, medic, manager, false, true, priorityModifier, 95)
+		end)
+	end
+	if not ok or newObjective == nil then return false end
+
+	pcall(function()
+		newObjective.ForceHighestPriority = true
+		newObjective.OverridePriority = fetch.selfCare and 85 or 95
+		newObjective.SpeakIfFails = false
+		newObjective.DebugLogWhenFails = false
+	end)
+
+	local added = pcall(function() manager.AddObjective(newObjective) end)
+	if added then
+		fetch.goTo = newObjective
+		BFA.State.itemObjectives[CharacterKey(medic)] = newObjective
+	end
+	return added == true
+end
+
+local function ProcessMedicalItemFetch(medic)
+	if medic == nil or medic.Inventory == nil then return false end
+
+	local fetchKey = CharacterKey(medic)
+	local fetch = BFA.State.itemFetches[fetchKey]
+	if fetch == nil then return false end
+
+	-- Medics and high-skill bots abort non-self-care fetches when any teammate
+	-- is in cardiac or respiratory arrest — resuscitation takes absolute priority.
+	if not fetch.selfCare
+		and (IsMedicalJob(medic) or GetMedicalSkill(medic) >= BFA.Settings.highSkillMedicalThreshold)
+		and Character ~= nil and Character.CharacterList ~= nil
+	then
+		for _, candidate in pairs(Character.CharacterList) do
+			if IsCrewHuman(candidate)
+				and candidate.TeamID == medic.TeamID
+				and NeedsResuscitation(candidate)
+			then
+				Log(CharacterName(medic) .. " aborted item fetch: cardiac/respiratory arrest on team")
+				ClearMedicalItemFetch(fetchKey)
+				return false
+			end
+		end
+	end
+
+	fetch.timeout = (fetch.timeout or BFA.Settings.itemFetchTimeoutTicks) - BFA.Settings.assistIntervalTicks
+	if fetch.timeout <= 0 then
+		Log(CharacterName(medic) .. " gave up fetching " .. ItemLabel(fetch.selectedIdentifier) .. ": timed out")
+		ClearMedicalItemFetch(fetchKey)
+		return false
+	end
+
+	fetch.targetTimeout = (fetch.targetTimeout or BFA.Settings.itemFetchTargetTimeoutTicks) - BFA.Settings.assistIntervalTicks
+	if fetch.targetTimeout <= 0 and fetch.targetItem ~= nil then
+		RejectFetchTarget(fetch, fetch.targetItem, "target stalled")
+	end
+
+	if FindRequestedInventoryItem(medic, fetch.identifiers) ~= nil then
+		Log(CharacterName(medic) .. " already has " .. ItemLabel(fetch.selectedIdentifier) .. " in inventory; ending fetch")
+		ClearMedicalItemFetch(fetchKey)
+		return false
+	end
+
+	local item, identifier = RefreshFetchTarget(fetch, medic)
+	if item == nil then
+		Log(CharacterName(medic) .. " gave up fetching medical item: target no longer exists")
+		ClearMedicalItemFetch(fetchKey)
+		return false
+	end
+
+	local canInteract, moveTarget = CanInteractWithFetchTarget(medic, item)
+	if canInteract then
+		if TryTakeNearbyItem(medic, item) then
+			Log(CharacterName(medic) .. " physically took " .. ItemLabel(identifier))
+			ClearMedicalItemFetch(fetchKey)
+			return false
+		end
+		fetch.takeFailures = (fetch.takeFailures or 0) + 1
+		if fetch.takeFailures >= 3 then
+			RejectFetchTarget(fetch, item, "take failed")
+		else
+			-- Keep the bot anchored at the container while retrying. Without this,
+			-- vanilla objectives walk the bot back to the patient and create a
+			-- cabinet ↔ patient loop on every tick.
+			EnsureFetchGoToObjective(medic, fetch, moveTarget)
+		end
+		return true
+	end
+
+	if EnsureFetchGoToObjective(medic, fetch, moveTarget) then return true end
+	RejectFetchTarget(fetch, item, "no path")
+	local nextItem = RefreshFetchTarget(fetch, medic)
+	if nextItem == nil then
+		Log(CharacterName(medic) .. " found no path to any accessible " .. ItemLabel(identifier))
+		ClearMedicalItemFetch(fetchKey)
+		return false
+	end
+	Log(CharacterName(medic) .. " switched fetch target to another " .. ItemLabel(identifier))
+	return true
+end
+
+function BFA.IsFetchingMedicalItem(medic)
+	return medic ~= nil and BFA.State.itemFetches[CharacterKey(medic)] ~= nil
+end
+
+local function IsBandageItem(item)
+	local identifier = ItemIdentifier(item)
+	return identifier == "antibleeding1"
+		or identifier == "bandage"
+		or identifier == "antibleeding2"
+		or identifier == "antibleeding3"
+end
+
+local function IsBotMedicalHeldItem(item)
+	local identifier = ItemIdentifier(item)
+	if identifier == nil then return false end
+	return IsBandageItem(item)
+		or identifier == "suture"
+		or identifier == "gypsum"
+		or identifier == "wrench"
+		or identifier == "heavywrench"
+		or identifier == "repairpack"
+		or identifier == "screwdriver"
+		or identifier == "antibloodloss2"
+		or identifier == "bloodpackominus"
+		or identifier == "tweezers"
+		or identifier == "traumashears"
+		or identifier == "divingknife"
+		or identifier == "aed"
+		or identifier == "autocpr"
+		or identifier == "bvm"
+		or identifier == "defibrillator"
+		or (HF ~= nil and HF.StartsWith ~= nil and HF.StartsWith(identifier, "bloodpack"))
+		or (HF ~= nil and HF.StartsWith ~= nil and HF.StartsWith(identifier, "divingknife"))
+end
+
+local complexMedicalEquipment = forbiddenComplexMedicalIdentifiers
+
+local function IsComplexMedicalEquipment(item)
+	local identifier = ItemIdentifier(item)
+	return identifier ~= nil and complexMedicalEquipment[identifier] == true
+end
+
+local function BotCanUseComplexMedicalEquipment(medic, patient, item)
+	if not IsComplexMedicalEquipment(item) then return true end
+	return false
+end
+
+local function StowForbiddenComplexMedicalEquipment(bot)
+	if bot == nil or bot.Inventory == nil then return end
+	if HF == nil or HF.GetItemInRightHand == nil or HF.GetItemInLeftHand == nil then return end
+
+	local heldItems = { HF.GetItemInRightHand(bot), HF.GetItemInLeftHand(bot) }
+	for index = 1, 2 do
+		local item = heldItems[index]
+		if item ~= nil and IsComplexMedicalEquipment(item) and IsDirectlyCarriedBy(bot, item) then
+			local stowed = false
+			pcall(function() stowed = bot.Inventory.TryPutItem(item, nil, { InvSlotType.Any }) end)
+			if not stowed then
+				pcall(function() item.Drop(bot, true) end)
+			end
+		end
+	end
+end
+
+-- Tools that non-medics borrow temporarily and should drop after use.
+-- Consumables (bandage, suture, gypsum, blood packs) and repair-multipurpose
+-- tools (wrench) are excluded — they are either spent or legitimately kept.
+local borrowedSpecialtyTools = {
+	tweezers = true,
+	traumashears = true,
+}
+
+local function ReturnBorrowedSpecialtyTools(bot)
+	if bot == nil or bot.Inventory == nil or bot.Inventory.AllItems == nil then return end
+	if IsMedicalJob(bot) then return end
+	for item in bot.Inventory.AllItems do
+		if item ~= nil and not item.Removed and item.Condition > 0 and IsDirectlyCarriedBy(bot, item) then
+			if borrowedSpecialtyTools[ItemIdentifier(item) or ""] == true then
+				pcall(function() item.Drop(bot, true) end)
+				Log(CharacterName(bot) .. " returned " .. ItemLabel(ItemIdentifier(item)))
+			end
+		end
+	end
+end
+
+local function StowHeldMedicalItems(medic)
+	if medic == nil or medic.Inventory == nil then return end
+	if HF == nil or HF.GetItemInRightHand == nil or HF.GetItemInLeftHand == nil then return end
+
+	local rightHand = HF.GetItemInRightHand(medic)
+	local leftHand = HF.GetItemInLeftHand(medic)
+	local heldItems = { rightHand, leftHand }
+	for index = 1, 2 do
+		local item = heldItems[index]
+		if item ~= nil and IsBotMedicalHeldItem(item) and IsDirectlyCarriedBy(medic, item) then
+			local stowed = false
+			pcall(function() stowed = medic.Inventory.TryPutItem(item, nil, { InvSlotType.Any }) end)
+			if not stowed then
+				pcall(function() item.Drop(medic, true) end)
+			end
+		end
+	end
+end
+
+local function ApplyItem(item, medic, patient, limb)
+	if item == nil or medic == nil or patient == nil or limb == nil or NT == nil then return false end
+	if IsBot(medic) and not BotCanUseComplexMedicalEquipment(medic, patient, item) then return false end
+	local identifier = ItemIdentifier(item)
+	if identifier == nil then return false end
+	local limbType = HF ~= nil and HF.NormalizeLimbType ~= nil and HF.NormalizeLimbType(limb.type) or limb.type
+	local actionDescription = CharacterName(medic)
+		.. " used "
+		.. ItemLabel(identifier)
+		.. " on "
+		.. CharacterName(patient)
+		.. " ("
+		.. LimbLabel(limbType)
+		.. ")"
+
+	if NT.ItemMethods ~= nil and NT.ItemMethods[identifier] ~= nil then
+		local ok, result = pcall(function()
+			return NT.ItemMethods[identifier](item, medic, patient, limb)
+		end)
+		if ok and result ~= false and identifier == "suture" and HF ~= nil and HF.RemoveItem ~= nil then
+			HF.RemoveItem(item)
+		end
+		Log(actionDescription .. (ok and result ~= false and " [ok]" or " [failed]"))
+		return ok and result ~= false
+	end
+
+	if NT.ItemStartsWithMethods ~= nil then
+		for prefix, method in pairs(NT.ItemStartsWithMethods) do
+			if HF ~= nil and HF.StartsWith ~= nil and HF.StartsWith(identifier, prefix) then
+				local ok, result = pcall(function()
+					return method(item, medic, patient, limb)
+				end)
+				Log(actionDescription .. (ok and result ~= false and " [ok]" or " [failed]"))
+				return ok and result ~= false
+			end
+		end
+	end
+
+	Log(actionDescription .. " [no Lua method]")
+	return false
+end
+
+local function LimbInjuryScore(patient, limbType)
+	local bleeding = GetAfflictionLimb(patient, limbType, "bleeding", 0)
+	local nonstop = GetAfflictionLimb(patient, limbType, "bleedingnonstop", 0)
+	local bandaged = GetAfflictionLimb(patient, limbType, "bandaged", 0)
+	local sutured = GetAfflictionLimb(patient, limbType, "suturedw", 0)
+	local dirtyBandage = GetAfflictionLimb(patient, limbType, "dirtybandage", 0)
+	local tourniquet = GetAfflictionLimb(patient, limbType, "arteriesclamp", 0)
+	local foreignBody = GetAfflictionLimb(patient, limbType, "foreignbody", 0)
+
+	if nonstop <= 0.1 and bandaged >= 50 and bleeding <= 5 then
+		bleeding = 0
+	elseif nonstop <= 0.1 and bandaged >= 25 and bleeding <= 2 then
+		bleeding = 0
+	end
+
+	local woundScore = GetAfflictionLimb(patient, limbType, "gunshotwound", 0) * 4
+		+ GetAfflictionLimb(patient, limbType, "lacerations", 0) * 3
+		+ GetAfflictionLimb(patient, limbType, "bitewounds", 0) * 3
+		+ GetAfflictionLimb(patient, limbType, "explosiondamage", 0) * 3
+
+	if bleeding <= 0.1 and nonstop <= 0.1 and (bandaged > 0.1 or sutured > 0.1) then
+		woundScore = 0
+	end
+
+	local maintenanceScore = 0
+	if dirtyBandage >= BFA.Settings.dirtyBandageCleanupThreshold and bleeding <= 5 and nonstop <= 0.1 then
+		maintenanceScore = maintenanceScore + 18 + dirtyBandage
+	end
+	if tourniquet > 0.1 and GetArterialCut(patient, limbType) <= 0.1 and bleeding <= 5 and nonstop <= 0.1 then
+		maintenanceScore = maintenanceScore + 35
+	end
+	if foreignBody >= BFA.Settings.foreignBodyRemovalThreshold then
+		local woundOpen = GetAfflictionLimb(patient, limbType, "gunshotwound", 0) >= 1
+			or GetAfflictionLimb(patient, limbType, "explosiondamage", 0) >= 1
+			or GetAfflictionLimb(patient, limbType, "retractedskin", 0) >= 99
+		if woundOpen and nonstop <= 0.1 and bleeding <= 15 then
+			maintenanceScore = maintenanceScore + 12 + foreignBody * 2
+			if foreignBody >= BFA.Settings.foreignBodyUrgentThreshold then
+				maintenanceScore = maintenanceScore + 20
+			end
+		end
+	end
+
+	local boneScore = 0
+	if LimbIsExtremity(limbType) then
+		if LimbIsBroken(patient, limbType)
+			and GetAfflictionLimb(patient, limbType, "gypsumcast", 0) <= 0.1
+			and not HasMissingResource(patient, "fracture_cast", limbType, "gypsum")
+		then
+			boneScore = boneScore + 35
+			if GetAfflictionLimb(patient, limbType, "bandaged", 0) >= BFA.Settings.fractureBandageThreshold then
+				boneScore = boneScore + 12
+			end
+		end
+		if LimbIsDislocated(patient, limbType) and not HasMissingResource(patient, "dislocation", limbType, "relocator") then
+			boneScore = boneScore + 28
+		end
+	end
+
+	return nonstop * 50 + bleeding * 3 + woundScore + boneScore + maintenanceScore
+end
+
+local function FindWorstTreatableLimb(patient)
+	local bestLimbType = nil
+	local bestScore = 0
+	for _, limbType in ipairs(limbTypes) do
+		local score = LimbInjuryScore(patient, limbType)
+		if score > bestScore then
+			bestScore = score
+			bestLimbType = limbType
+		end
+	end
+
+	if bestLimbType == nil or bestScore <= 0 then return nil, 0 end
+	return LimbObject(patient, bestLimbType), bestScore
+end
+
+local function PatientTreatmentScore(character)
+	if character == nil then return 0 end
+	local score = GetAffliction(character, "bloodloss", 0)
+		+ GetAffliction(character, "oxygenlow", 0)
+		+ GetAffliction(character, "hypoxemia", 0)
+		+ GetAffliction(character, "cardiacarrest", 0) * 100
+		+ GetAffliction(character, "respiratoryarrest", 0) * 90
+
+	for _, limbType in ipairs(limbTypes) do
+		score = score + LimbInjuryScore(character, limbType)
+	end
+
+	return score
+end
+
+local function PatientIsIncapacitated(character)
+	if character == nil then return false end
+	if SafeProperty(character, "IsIncapacitated", false) == true then return true end
+	if SafeProperty(character, "IsUnconscious", false) == true then return true end
+	return GetAffliction(character, "sym_unconsciousness", 0) > 0.1
+		or GetAffliction(character, "stun", 0) > 1
+end
+
+local function NeedsWoundClosure(patient, limbType)
+	if GetAfflictionLimb(patient, limbType, "suturedw", 0) > 0.1 then return false end
+	return GetAfflictionLimb(patient, limbType, "gunshotwound", 0) > 0.1
+		or GetAfflictionLimb(patient, limbType, "lacerations", 0) > 0.1
+		or GetAfflictionLimb(patient, limbType, "bitewounds", 0) > 0.1
+		or GetAfflictionLimb(patient, limbType, "explosiondamage", 0) > 0.1
+		or GetAfflictionLimb(patient, limbType, "bleedingnonstop", 0) > 0.1
+end
+
+local function NeedsBleedingControl(patient, limbType)
+	local bleeding = GetAfflictionLimb(patient, limbType, "bleeding", 0)
+	local nonstop = GetAfflictionLimb(patient, limbType, "bleedingnonstop", 0)
+	local bandaged = GetAfflictionLimb(patient, limbType, "bandaged", 0)
+
+	-- At 50 %+ coverage with no continuous bleed the wound is managed; remaining
+	-- bleeding will decay on its own. Previously required bleeding <= 5 here,
+	-- which caused bots to stack bandages when bleeding was still 6-15 post-wrap.
+	if bandaged >= 50 and nonstop <= 0.1 then return false end
+	if bandaged >= 25 and bleeding <= 5 and nonstop <= 0.1 then return false end
+	if bandaged > 0.1 and bleeding <= 0.1 and nonstop <= 0.1 then return false end
+
+	return bleeding > 0.1 or nonstop > 0.1
+end
+
+local function PatientNeedsBandage(patient)
+	for _, limbType in ipairs(limbTypes) do
+		if NeedsBleedingControl(patient, limbType) then return true end
+		if LimbIsExtremity(limbType)
+			and LimbIsBroken(patient, limbType)
+			and GetAfflictionLimb(patient, limbType, "gypsumcast", 0) <= 0.1
+			and GetAfflictionLimb(patient, limbType, "surgeryincision", 0) <= 1
+			and not HasMissingResource(patient, "fracture_cast", limbType, "gypsum")
+			and GetAfflictionLimb(patient, limbType, "bandaged", 0) < BFA.Settings.fractureBandageThreshold
+		then
+			return true
+		end
+	end
+	return false
+end
+
+local function PatientHasPendingBoneCare(patient)
+	for _, limbType in ipairs(limbTypes) do
+		if LimbIsExtremity(limbType) then
+			if LimbIsDislocated(patient, limbType) then return true end
+			if LimbIsBroken(patient, limbType)
+				and GetAfflictionLimb(patient, limbType, "gypsumcast", 0) <= 0.1
+				and not HasMissingResource(patient, "fracture_cast", limbType, "gypsum")
+			then
+				return true
+			end
+		end
+	end
+	return false
+end
+
+local function PatientFunctionalBoneScore(patient)
+	local score = 0
+	local affectedLimbs = 0
+	for _, limbType in ipairs(limbTypes) do
+		if LimbIsExtremity(limbType) then
+			local limbAffected = false
+			if LimbIsBroken(patient, limbType)
+				and GetAfflictionLimb(patient, limbType, "gypsumcast", 0) <= 0.1
+				and not HasMissingResource(patient, "fracture_cast", limbType, "gypsum")
+			then
+				score = score + 45
+				limbAffected = true
+			end
+			if LimbIsDislocated(patient, limbType)
+				and not HasMissingResource(patient, "dislocation", limbType, "relocator")
+			then
+				score = score + 35
+				limbAffected = true
+			end
+			if limbAffected then affectedLimbs = affectedLimbs + 1 end
+		end
+	end
+
+	if affectedLimbs >= 2 then score = score + 35 end
+	if affectedLimbs >= 3 then score = score + 35 end
+	return score
+end
+
+local function PatientNeedsFunctionalBoneCare(patient)
+	return PatientFunctionalBoneScore(patient) > 0
+end
+
+local function StowStaleHeldBandage(medic, patient)
+	if medic == nil or patient == nil or medic.Inventory == nil then return end
+	if PatientNeedsBandage(patient) then return end
+	if HF == nil or HF.GetItemInRightHand == nil or HF.GetItemInLeftHand == nil then return end
+
+	local rightHand = HF.GetItemInRightHand(medic)
+	local leftHand = HF.GetItemInLeftHand(medic)
+	local heldItems = { rightHand, leftHand }
+	for index = 1, 2 do
+		local item = heldItems[index]
+		if item ~= nil and IsBandageItem(item) and IsDirectlyCarriedBy(medic, item) then
+			pcall(function() medic.Inventory.TryPutItem(item, nil, { InvSlotType.Any }) end)
+		end
+	end
+end
+
+local function NeedsFractureSplint(patient, limbType)
+	if not LimbIsExtremity(limbType) or not LimbIsBroken(patient, limbType) then return false end
+	if GetAfflictionLimb(patient, limbType, "gypsumcast", 0) > 0.1 then return false end
+	if GetAfflictionLimb(patient, limbType, "surgeryincision", 0) > 1 then return false end
+	if HasMissingResource(patient, "fracture_cast", limbType, "gypsum") then return false end
+	return true
+end
+
+local function PatientNeedsFractureCast(patient)
+	for _, limbType in ipairs(limbTypes) do
+		if NeedsFractureSplint(patient, limbType) then return true end
+	end
+	return false
+end
+
+local function SelectFractureItem(medic, patient, limbType)
+	if not NeedsFractureSplint(patient, limbType) then return nil end
+
+	if GetAfflictionLimb(patient, limbType, "bandaged", 0) < BFA.Settings.fractureBandageThreshold then
+		return FindInventoryItem(medic, { "antibleeding1", "antibleeding2" })
+	end
+
+	return FindInventoryItem(medic, { "gypsum" })
+end
+
+local function ApplyGypsumCastForBot(gypsum, medic, patient, limb, limbType)
+	if gypsum == nil or limb == nil or limbType == nil then return false end
+	if not NeedsFractureSplint(patient, limbType) then return false end
+	if GetAfflictionLimb(patient, limbType, "bandaged", 0) <= 0.1 then return false end
+
+	local before = GetAfflictionLimb(patient, limbType, "gypsumcast", 0)
+	if not ApplyItem(gypsum, medic, patient, limb) then return false end
+
+	return GetAfflictionLimb(patient, limbType, "gypsumcast", 0) > before
+end
+
+local function TryPreparedFractureTreatment(medic, patient)
+	local state = GetProcedureState(medic, patient, "fracture_cast")
+
+	local limb, limbType = FindFractureLimb(patient, false, state.limb)
+	if limb == nil or limbType == nil then return false end
+	state.limb = LimbKey(limbType)
+	state.step = "cast"
+
+	local gypsum = FindInventoryItem(medic, { "gypsum" })
+	if gypsum == nil then
+		if FindAvailableWorldItem("gypsum", medic, nil) ~= nil then
+			Log(CharacterName(medic) .. " wants to cast " .. CharacterName(patient) .. " (" .. LimbLabel(limbType) .. "), but needs to fetch cast")
+			RequestMedicalItem(medic, { "gypsum" }, 8, medic == patient)
+		else
+			Log(CharacterName(medic) .. " wants to cast " .. CharacterName(patient) .. " (" .. LimbLabel(limbType) .. "), but no cast available")
+			MarkMissingResource(patient, "fracture_cast", limbType, "gypsum")
+			ClearProcedureState(medic, patient, "fracture_cast")
+		end
+		return false
+	end
+
+	if ApplyGypsumCastForBot(gypsum, medic, patient, limb, limbType) then
+		Log(CharacterName(medic) .. " applied cast to " .. CharacterName(patient) .. " (" .. LimbLabel(limbType) .. ")")
+		ClearProcedureState(medic, patient, "fracture_cast")
+		return true
+	end
+
+	Log(CharacterName(medic) .. " tried to cast " .. CharacterName(patient) .. " (" .. LimbLabel(limbType) .. "), but cast did not apply")
+	return false
+end
+
+local function TryUnpreparedFractureTreatment(medic, patient)
+	local state = GetProcedureState(medic, patient, "fracture_cast")
+
+	local limb, limbType = FindFractureLimb(patient, true, state.limb)
+	if limb == nil or limbType == nil then return false end
+	state.limb = LimbKey(limbType)
+	state.step = "bandage"
+
+	local bandage = FindInventoryItem(medic, { "antibleeding1", "antibleeding2" })
+	if bandage == nil then
+		Log(CharacterName(medic) .. " wants to prep fracture on " .. CharacterName(patient) .. " (" .. LimbLabel(limbType) .. "), but no bandage in inventory")
+		return false
+	end
+
+	return ApplyItem(bandage, medic, patient, limb)
+end
+
+local function TryFractureTreatment(medic, patient)
+	if not PatientNeedsFractureCast(patient) then
+		ClearProcedureState(medic, patient, "fracture_cast")
+		return false
+	end
+
+	if TryPreparedFractureTreatment(medic, patient) then return true end
+	return TryUnpreparedFractureTreatment(medic, patient)
+end
+
+SequentialProcedures.fracture_cast = TryFractureTreatment
+
+local function PatientHasUnstableEmergency(patient)
+	if NeedsResuscitation(patient) or BloodLossValue(patient) >= 45 then return true end
+
+	for _, limbType in ipairs(limbTypes) do
+		local bleeding = GetAfflictionLimb(patient, limbType, "bleeding", 0)
+		local nonstop = GetAfflictionLimb(patient, limbType, "bleedingnonstop", 0)
+		local unclampedArtery = GetArterialCut(patient, limbType) > 0.1
+			and GetAfflictionLimb(patient, limbType, "arteriesclamp", 0) <= 0.1
+		if nonstop > 0.1 or bleeding > 20 or unclampedArtery then return true end
+	end
+
+	return false
+end
+
+local function LimbHasOpenForeignBodyAccess(patient, limbType)
+	return GetAfflictionLimb(patient, limbType, "gunshotwound", 0) >= 1
+		or GetAfflictionLimb(patient, limbType, "explosiondamage", 0) >= 1
+		or GetAfflictionLimb(patient, limbType, "retractedskin", 0) >= 99
+end
+
+local function NeedsForeignBodyRemoval(patient, limbType)
+	if GetAfflictionLimb(patient, limbType, "foreignbody", 0) < BFA.Settings.foreignBodyRemovalThreshold then return false end
+	if not LimbHasOpenForeignBodyAccess(patient, limbType) then return false end
+	if GetAfflictionLimb(patient, limbType, "bleedingnonstop", 0) > 0.1 then return false end
+	if GetAfflictionLimb(patient, limbType, "bleeding", 0) > 15 then return false end
+	if HasMissingResource(patient, "foreign_body", limbType, "tweezers") then return false end
+	return true
+end
+
+local function BotCanRemoveForeignBody(medic)
+	return HasSurgerySkill(medic, 30) or GetSurgerySkill(medic) >= 30
+end
+
+local function FindForeignBodyLimb(patient)
+	local bestLimbType = nil
+	local bestScore = 0
+	for _, limbType in ipairs(limbTypes) do
+		if NeedsForeignBodyRemoval(patient, limbType) then
+			local foreignBody = GetAfflictionLimb(patient, limbType, "foreignbody", 0)
+			local score = foreignBody
+				+ GetAfflictionLimb(patient, limbType, "gunshotwound", 0)
+				+ GetAfflictionLimb(patient, limbType, "explosiondamage", 0)
+			if foreignBody >= BFA.Settings.foreignBodyUrgentThreshold then score = score + 100 end
+			if score > bestScore then
+				bestScore = score
+				bestLimbType = limbType
+			end
+		end
+	end
+
+	if bestLimbType == nil then return nil, nil end
+	return LimbObject(patient, bestLimbType), bestLimbType
+end
+
+local function TryForeignBodyRemoval(medic, patient)
+	if PatientHasUnstableEmergency(patient) or not BotCanRemoveForeignBody(medic) then return false end
+
+	local limb, limbType = FindForeignBodyLimb(patient)
+	if limb == nil or limbType == nil then return false end
+
+	local tweezers = FindInventoryItem(medic, { "tweezers" })
+	if tweezers == nil then
+		if FindAvailableWorldItem("tweezers", medic, nil) == nil then
+			MarkMissingResource(patient, "foreign_body", limbType, "tweezers")
+			Log(CharacterName(medic) .. " wants to remove foreign body from " .. CharacterName(patient) .. " (" .. LimbLabel(limbType) .. "), but no tweezers available")
+		else
+			Log(CharacterName(medic) .. " wants to remove foreign body from " .. CharacterName(patient) .. " (" .. LimbLabel(limbType) .. "), but needs to fetch tweezers")
+			RequestMedicalItem(medic, { "tweezers" }, 8, medic == patient)
+		end
+		return false
+	end
+
+	local before = GetAfflictionLimb(patient, limbType, "foreignbody", 0)
+	if not ApplyItem(tweezers, medic, patient, limb) then return false end
+
+	local after = GetAfflictionLimb(patient, limbType, "foreignbody", 0)
+	if after < before then
+		Log(CharacterName(medic) .. " removed part of foreign body from " .. CharacterName(patient) .. " (" .. LimbLabel(limbType) .. ")")
+		return true
+	end
+
+	return false
+end
+
+local function NeedsDirtyBandageRemoval(patient, limbType)
+	if GetAfflictionLimb(patient, limbType, "dirtybandage", 0) < BFA.Settings.dirtyBandageCleanupThreshold then return false end
+	if GetAfflictionLimb(patient, limbType, "bleedingnonstop", 0) > 0.1 then return false end
+	if GetAfflictionLimb(patient, limbType, "bleeding", 0) > 5 then return false end
+	return true
+end
+
+local function NeedsTourniquetRemoval(patient, limbType)
+	if GetAfflictionLimb(patient, limbType, "arteriesclamp", 0) <= 0.1 then return false end
+	if GetArterialCut(patient, limbType) > 0.1 then return false end
+	if GetAfflictionLimb(patient, limbType, "bleedingnonstop", 0) > 0.1 then return false end
+	if GetAfflictionLimb(patient, limbType, "bleeding", 0) > 5 then return false end
+	return true
+end
+
+local function FindCleanupLimb(patient)
+	local bestLimbType = nil
+	local bestScore = 0
+	for _, limbType in ipairs(limbTypes) do
+		if not HasMissingResource(patient, "cleanup", limbType, "cutter") then
+			local score = 0
+			if NeedsTourniquetRemoval(patient, limbType) then score = score + 100 end
+			if NeedsDirtyBandageRemoval(patient, limbType) then
+				score = score + 40 + GetAfflictionLimb(patient, limbType, "dirtybandage", 0)
+			end
+			if score > bestScore then
+				bestScore = score
+				bestLimbType = limbType
+			end
+		end
+	end
+
+	if bestLimbType == nil then return nil, nil end
+	return LimbObject(patient, bestLimbType), bestLimbType
+end
+
+local function FindSafeCuttingItem(medic, patient, limbType)
+	local gypsumCast = GetAfflictionLimb(patient, limbType, "gypsumcast", 0)
+
+	if gypsumCast <= 0.1 then
+		local shears = FindInventoryItem(medic, { "traumashears" })
+		if shears ~= nil then return shears end
+	end
+
+	if GetMedicalSkill(medic) >= 30 then
+		local knife = FindInventoryItem(medic, { "divingknife" })
+		if knife ~= nil then return knife end
+	end
+
+	return nil
+end
+
+local function TryCleanupTemporaryTreatment(medic, patient)
+	if PatientHasUnstableEmergency(patient) then return false end
+
+	local limb, limbType = FindCleanupLimb(patient)
+	if limb == nil or limbType == nil then return false end
+
+	local item = FindSafeCuttingItem(medic, patient, limbType)
+	if item == nil then
+		local canUseKnife = GetMedicalSkill(medic) >= 30
+		local shearsAvailable = FindAvailableWorldItem("traumashears", medic, nil) ~= nil
+		local knifeAvailable = FindAvailableWorldItem("divingknife", medic, nil) ~= nil
+		if not shearsAvailable and (not canUseKnife or not knifeAvailable) then
+			MarkMissingResource(patient, "cleanup", limbType, "cutter")
+			Log(CharacterName(medic) .. " wants to remove bandage/tourniquet from " .. CharacterName(patient) .. " (" .. LimbLabel(limbType) .. "), but no safe cutter available")
+		else
+			Log(CharacterName(medic) .. " wants to remove bandage/tourniquet from " .. CharacterName(patient) .. " (" .. LimbLabel(limbType) .. "), but needs to fetch cutter")
+			if GetAfflictionLimb(patient, limbType, "gypsumcast", 0) <= 0.1 then
+				if canUseKnife then
+					RequestMedicalItem(medic, { "traumashears", "divingknife" }, 8, medic == patient)
+				else
+					RequestMedicalItem(medic, { "traumashears" }, 8, medic == patient)
+				end
+			elseif shearsAvailable then
+				RequestMedicalItem(medic, { "traumashears" }, 8, medic == patient)
+			end
+		end
+		return false
+	end
+
+	local dirtyBefore = GetAfflictionLimb(patient, limbType, "dirtybandage", 0)
+	local clampBefore = GetAfflictionLimb(patient, limbType, "arteriesclamp", 0)
+	if not ApplyItem(item, medic, patient, limb) then return false end
+
+	local dirtyAfter = GetAfflictionLimb(patient, limbType, "dirtybandage", 0)
+	local clampAfter = GetAfflictionLimb(patient, limbType, "arteriesclamp", 0)
+	return dirtyAfter < dirtyBefore or clampAfter < clampBefore
+end
+
+local function TrySequentialProcedure(medic, patient, procedureName)
+	local procedure = SequentialProcedures[procedureName]
+	if procedure == nil then return false end
+	return procedure(medic, patient) == true
+end
+
+local function PatientHasActionableHigherPriorityThanBoneCare(medic, patient, allowRequest)
+	if NeedsResuscitation(patient) then return true, "resuscitation" end
+
+	local bloodCandidates = {
+		"antibloodloss2",
+		"bloodpackominus",
+		"bloodpackoplus",
+		"bloodpackaminus",
+		"bloodpackaplus",
+		"bloodpackbminus",
+		"bloodpackbplus",
+		"bloodpackabminus",
+		"bloodpackabplus",
+	}
+
+	if BloodLossValue(patient) >= 45
+		and FindInventoryItem(medic, bloodCandidates) ~= nil
+	then
+		return true, "blood loss"
+	end
+	if BloodLossValue(patient) >= 45 and allowRequest == true then
+		for _, identifier in ipairs(bloodCandidates) do
+			if FindAvailableWorldItem(identifier, medic, nil) ~= nil then
+				RequestMedicalItem(medic, bloodCandidates, 8, medic == patient)
+				return true, "fetching blood loss treatment"
+			end
+		end
+	end
+
+	for _, limbType in ipairs(limbTypes) do
+		local bleedingCandidates = { "antibleeding3", "antibleeding2", "antibleeding1", "bandage" }
+		if NeedsBleedingControl(patient, limbType)
+			and FindInventoryItem(medic, bleedingCandidates) ~= nil
+		then
+			return true, "bleeding on " .. LimbLabel(limbType)
+		end
+		if NeedsBleedingControl(patient, limbType) and allowRequest == true then
+			for _, identifier in ipairs(bleedingCandidates) do
+				if FindAvailableWorldItem(identifier, medic, nil) ~= nil then
+					RequestMedicalItem(medic, { "antibleeding1", "bandage", "antibleeding2", "antibleeding3" }, 8, medic == patient)
+					return true, "fetching bandage for " .. LimbLabel(limbType)
+				end
+			end
+		end
+
+		local bleeding = GetAfflictionLimb(patient, limbType, "bleeding", 0)
+		local nonstop = GetAfflictionLimb(patient, limbType, "bleedingnonstop", 0)
+		local sutured = GetAfflictionLimb(patient, limbType, "suturedw", 0)
+		if NeedsWoundClosure(patient, limbType)
+			and sutured <= 0.1
+			and (nonstop > 0.1 or bleeding > 1)
+			and GetMedicalSkill(medic) >= 30
+			and FindInventoryItem(medic, { "suture" }) ~= nil
+		then
+			return true, "suture on " .. LimbLabel(limbType)
+		end
+		if NeedsWoundClosure(patient, limbType)
+			and sutured <= 0.1
+			and (nonstop > 0.1 or bleeding > 1)
+			and GetMedicalSkill(medic) >= 30
+			and allowRequest == true
+			and FindAvailableWorldItem("suture", medic, nil) ~= nil
+		then
+			RequestMedicalItem(medic, { "suture" }, 8, medic == patient)
+			return true, "fetching suture for " .. LimbLabel(limbType)
+		end
+	end
+
+	return false, nil
+end
+
+local function SelectDislocationItem(medic, patient, limbType)
+	if not LimbIsExtremity(limbType) or not LimbIsDislocated(patient, limbType) then return nil end
+
+	if not BotCanRelocateDislocation(medic, patient) then return nil end
+
+	return FindInventoryItem(medic, { "wrench", "repairpack" })
+end
+
+local function ApplyDislocationRelocation(item, medic, patient, limbType)
+	if item == nil or medic == nil or patient == nil or limbType == nil then return false end
+	if NT == nil or NT.DislocateLimb == nil or not LimbIsDislocated(patient, limbType) then return false end
+
+	local identifier = DislocationIdentifier(limbType)
+	local before = identifier ~= nil and GetAffliction(patient, identifier, 0) or 0
+
+	if identifier ~= nil and HF ~= nil and HF.SetAffliction ~= nil then
+		pcall(function() HF.SetAffliction(patient, identifier, 0, medic, before) end)
+	else
+		NT.DislocateLimb(patient, limbType, -1000)
+	end
+
+	if HF ~= nil then
+		if HF.GiveSkillScaled ~= nil then HF.GiveSkillScaled(medic, "medical", 4000) end
+		if HF.GiveItem ~= nil then pcall(function() HF.GiveItem(patient, "ntsfx_velcro") end) end
+		if HF.HasAffliction ~= nil and HF.AddAffliction ~= nil and not HF.HasAffliction(patient, "analgesia", 0.5) then
+			HF.AddAffliction(patient, "severepain", 5, medic)
+		end
+	end
+
+	local fixed = not LimbIsDislocated(patient, limbType)
+	Log(CharacterName(medic) .. (fixed and " relocated " or " tried to relocate ")
+		.. CharacterName(patient)
+		.. " ("
+		.. LimbLabel(limbType)
+		.. ", before="
+		.. tostring(before)
+		.. ")")
+	return fixed
+end
+
+local function TryDislocationTreatment(medic, patient)
+	local limb, limbType = FindDislocatedLimb(patient)
+	if limb == nil or limbType == nil then return false end
+
+	if not BotCanRelocateDislocation(medic, patient) then
+		Log(CharacterName(medic) .. " cannot relocate dislocation on " .. CharacterName(patient) .. ": missing permission/skill")
+		StowHeldMedicalItems(medic)
+		return false
+	end
+	local hasHigherPriority, higherPriorityReason = PatientHasActionableHigherPriorityThanBoneCare(medic, patient, true)
+	if hasHigherPriority then
+		if BFA.State.itemFetches[CharacterKey(medic)] == nil then
+			Log(CharacterName(medic) .. " deferred relocation of " .. CharacterName(patient) .. ": higher priority actionable (" .. tostring(higherPriorityReason) .. ")")
+		end
+		return false
+	end
+
+	local item = SelectDislocationItem(medic, patient, limbType)
+	if item == nil then
+		local requestStarted = false
+		local wrenchAvailable = FindAvailableWorldItem("wrench", medic, nil) ~= nil
+		if wrenchAvailable then
+			Log(CharacterName(medic) .. " wants to relocate " .. CharacterName(patient) .. " (" .. LimbLabel(limbType) .. "), but needs to fetch tool")
+			requestStarted = RequestMedicalItem(medic, { "wrench" }, 6, medic == patient)
+		else
+			Log(CharacterName(medic) .. " wants to relocate " .. CharacterName(patient) .. " (" .. LimbLabel(limbType) .. "), but no tool available")
+			MarkMissingResource(patient, "dislocation", limbType, "relocator")
+		end
+		StowHeldMedicalItems(medic)
+		pcall(function() medic.DeselectCharacter() end)
+		pcall(function() medic.SelectedCharacter = nil end)
+		return requestStarted or wrenchAvailable
+	end
+
+	local fixed = ApplyDislocationRelocation(item, medic, patient, limbType)
+	if not fixed then
+		StowHeldMedicalItems(medic)
+		pcall(function() medic.DeselectCharacter() end)
+		pcall(function() medic.SelectedCharacter = nil end)
+	end
+	return true
+end
+
+local function StowStaleHeldBoneItems(medic, patient)
+	if medic == nil or medic.Inventory == nil then return end
+	if HF == nil or HF.GetItemInRightHand == nil or HF.GetItemInLeftHand == nil then return end
+	local hasHigherPriority = PatientHasActionableHigherPriorityThanBoneCare(medic, patient, false)
+	if PatientHasPendingBoneCare(patient) and not hasHigherPriority then return end
+
+	local heldItems = { HF.GetItemInRightHand(medic), HF.GetItemInLeftHand(medic) }
+	for index = 1, 2 do
+		local item = heldItems[index]
+		local identifier = ItemIdentifier(item)
+		if item ~= nil
+			and IsDirectlyCarriedBy(medic, item)
+			and (identifier == "wrench" or identifier == "heavywrench" or identifier == "repairpack" or identifier == "screwdriver" or identifier == "gypsum")
+		then
+			pcall(function() medic.Inventory.TryPutItem(item, nil, { InvSlotType.Any }) end)
+		end
+	end
+end
+
+local function SelectFallbackItem(medic, patient, limbType)
+	if NeedsWoundClosure(patient, limbType) then
+		local suture = FindInventoryItem(medic, { "suture" })
+		if suture ~= nil then return suture end
+	end
+
+	if NeedsBleedingControl(patient, limbType) then
+		local nonstop = GetAfflictionLimb(patient, limbType, "bleedingnonstop", 0)
+		local bandaged = GetAfflictionLimb(patient, limbType, "bandaged", 0)
+		-- Non-medics stop stacking bandages at 30 % coverage (unless nonstop bleed).
+		-- Medics tolerate up to 50 % (already handled in NeedsBleedingControl).
+		local softCap = IsMedicalJob(medic) and 50 or 30
+		if bandaged < softCap or nonstop > 0.1 then
+			local bandage = FindInventoryItem(medic, { "antibleeding3", "antibleeding2", "antibleeding1", "bandage" })
+			if bandage ~= nil then return bandage end
+		end
+	end
+
+	local fractureItem = SelectFractureItem(medic, patient, limbType)
+	if fractureItem ~= nil then return fractureItem end
+
+	return nil
+end
+
+local function BloodPackType(item)
+	local identifier = ItemIdentifier(item)
+	if identifier == nil then return nil end
+	if identifier == "antibloodloss2" or identifier == "bloodpackominus" then return "ominus" end
+	if HF ~= nil and HF.StartsWith ~= nil and HF.StartsWith(identifier, "bloodpack") then
+		return string.sub(identifier, string.len("bloodpack") + 1)
+	end
+	return nil
+end
+
+local function IsCompatibleBloodPack(item, patient)
+	if NT == nil or NT.GetBloodtype == nil then return false end
+	local packtype = BloodPackType(item)
+	if packtype == nil then return false end
+
+	local targettype = NT.GetBloodtype(patient)
+	if targettype == nil then return packtype == "ominus" end
+
+	local packhasA = string.find(packtype, "a") ~= nil
+	local packhasB = string.find(packtype, "b") ~= nil
+	local packhasRh = string.find(packtype, "plus") ~= nil
+	local targethasA = string.find(targettype, "a") ~= nil
+	local targethasB = string.find(targettype, "b") ~= nil
+	local targethasRh = string.find(targettype, "plus") ~= nil
+
+	return (targethasRh or not packhasRh)
+		and (targethasA or not packhasA)
+		and (targethasB or not packhasB)
+end
+
+local function IsUsableBloodPack(item, patient)
+	if item == nil or item.Removed or item.Condition <= 0 then return false end
+	local identifier = ItemIdentifier(item)
+	if identifier == "antibloodloss2" or identifier == "bloodpackominus" then return true end
+	return BloodPackType(item) ~= nil and IsCompatibleBloodPack(item, patient)
+end
+
+BloodLossValue = function(patient)
+	local afflictionBloodloss = GetAffliction(patient, "bloodloss", 0)
+	local characterBloodloss = SafeProperty(patient, "Bloodloss", 0) or 0
+	if characterBloodloss > afflictionBloodloss then return characterBloodloss end
+	return afflictionBloodloss
+end
+
+local function PatientNeedsBloodPack(patient)
+	local bloodpressure = GetAffliction(patient, "bloodpressure", 0)
+	return BloodLossValue(patient) >= 35
+		or (bloodpressure > 0 and bloodpressure < 60)
+end
+
+local function PatientCanUseHeldBloodPack(patient)
+	local bloodpressure = GetAffliction(patient, "bloodpressure", 0)
+	return BloodLossValue(patient) >= 20
+		or (bloodpressure > 0 and bloodpressure < 70)
+end
+
+local bloodPackIdentifiers = {
+	"antibloodloss2",
+	"bloodpackominus",
+	"bloodpackoplus",
+	"bloodpackaminus",
+	"bloodpackaplus",
+	"bloodpackbminus",
+	"bloodpackbplus",
+	"bloodpackabminus",
+	"bloodpackabplus",
+}
+
+local function FindCompatibleBloodPack(medic, patient)
+	if medic == nil or medic.Inventory == nil or medic.Inventory.AllItems == nil then return nil end
+
+	if HF ~= nil and HF.GetItemInRightHand ~= nil and HF.GetItemInLeftHand ~= nil then
+		local rightHand = HF.GetItemInRightHand(medic)
+		local leftHand = HF.GetItemInLeftHand(medic)
+		local heldItems = { rightHand, leftHand }
+		for index = 1, 2 do
+			local item = heldItems[index]
+			if IsUsableBloodPack(item, patient) and IsDirectlyCarriedBy(medic, item) then return item end
+		end
+	end
+
+	local fallback = nil
+	for item in medic.Inventory.AllItems do
+		if item ~= nil and not item.Removed and item.Condition > 0 and IsDirectlyCarriedBy(medic, item) then
+			local identifier = ItemIdentifier(item)
+			for _, candidate in ipairs(bloodPackIdentifiers) do
+				if identifier == candidate then
+					if IsUsableBloodPack(item, patient) then
+						if identifier == "antibloodloss2" or identifier == "bloodpackominus" then return item end
+						fallback = item
+					end
+				end
+			end
+		end
+	end
+	return fallback
+end
+
+local function FindHeldCompatibleBloodPack(medic, patient)
+	if HF == nil or HF.GetItemInRightHand == nil or HF.GetItemInLeftHand == nil then return nil end
+
+	local rightHand = HF.GetItemInRightHand(medic)
+	local leftHand = HF.GetItemInLeftHand(medic)
+	local heldItems = { rightHand, leftHand }
+	for index = 1, 2 do
+		local item = heldItems[index]
+		if IsUsableBloodPack(item, patient) and IsDirectlyCarriedBy(medic, item) then return item end
+	end
+
+	return nil
+end
+
+local function SelectSystemicFallbackItem(medic, patient)
+	local bloodloss = BloodLossValue(patient)
+	if bloodloss >= 45 then
+		local bloodPack = FindCompatibleBloodPack(medic, patient)
+		if bloodPack ~= nil then return bloodPack end
+	end
+
+	return nil
+end
+
+local function CloseEnoughToTreat(medic, patient)
+	if medic == patient then return true end
+	local medicPos = SafeProperty(medic, "WorldPosition", nil)
+	local patientPos = SafeProperty(patient, "WorldPosition", nil)
+	if medicPos == nil or patientPos == nil then return false end
+	return Distance(medicPos, patientPos) <= BFA.Settings.maxOtherTreatmentDistance
+end
+
+local function IsSelectedPatient(medic, patient)
+	return SafeProperty(medic, "SelectedCharacter", nil) == patient
+end
+
+NeedsResuscitation = function(patient)
+	return GetAffliction(patient, "cardiacarrest", 0) > 0.1
+		or GetAffliction(patient, "respiratoryarrest", 0) > 0.1
+end
+
+local function CPRAnimationValue()
+	if AnimControllerAnimation == nil then return nil end
+
+	local value = nil
+	pcall(function() value = AnimControllerAnimation.CPR end)
+	if value == nil then
+		pcall(function() value = AnimControllerAnimation["CPR"] end)
+	end
+	return value
+end
+
+local function StartCPRAnimation(medic)
+	local animController = SafeProperty(medic, "AnimController", nil)
+	local cprAnimation = CPRAnimationValue()
+	if animController == nil or cprAnimation == nil then return false end
+
+	local ok = pcall(function() animController.StartAnimation(cprAnimation) end)
+	if ok then return true end
+
+	ok = pcall(function() animController.Anim = cprAnimation end)
+	return ok == true
+end
+
+local function StopCPRAnimation(medic)
+	local animController = SafeProperty(medic, "AnimController", nil)
+	local cprAnimation = CPRAnimationValue()
+	if animController == nil or cprAnimation == nil then return end
+
+	pcall(function() animController.StopAnimation(cprAnimation) end)
+end
+
+local function ClearBotCPRState(medicKey)
+	local state = BFA.State.cpr[medicKey]
+	if state ~= nil then
+		StopCPRAnimation(state.medic)
+		if state.medic ~= nil and state.patient ~= nil and IsSelectedPatient(state.medic, state.patient) then
+			pcall(function() state.medic.DeselectCharacter() end)
+			pcall(function() state.medic.SelectedCharacter = nil end)
+		end
+	end
+	BFA.State.cpr[medicKey] = nil
+end
+
+local function RefreshBotCPRBuffs(medic, patient)
+	if HF ~= nil and HF.HasAffliction ~= nil and HF.SetAffliction ~= nil then
+		pcall(function()
+			if not HF.HasAffliction(patient, "luabotomy") then HF.SetAffliction(patient, "luabotomy", 1) end
+		end)
+	end
+
+	if GetAffliction(patient, "cpr_buff", 0) < 3 then AddAffliction(patient, "cpr_buff", 2, medic) end
+	if GetAffliction(patient, "cpr_fracturebuff", 0) < 3 then AddAffliction(patient, "cpr_fracturebuff", 2, medic) end
+end
+
+local function CleanupBotCPRStates()
+	for medicKey, state in pairs(BFA.State.cpr) do
+		local medic = state ~= nil and state.medic or nil
+		local patient = state ~= nil and state.patient or nil
+		if not IsCrewHuman(medic)
+			or not IsCrewHuman(patient)
+			or patient.TeamID ~= medic.TeamID
+			or patient.IsDead
+			or patient.Removed
+			or not NeedsResuscitation(patient)
+		then
+			ClearBotCPRState(medicKey)
+		end
+	end
+end
+
+local function MaintainBotCPRStates()
+	for medicKey, state in pairs(BFA.State.cpr) do
+		local medic = state ~= nil and state.medic or nil
+		local patient = state ~= nil and state.patient or nil
+		if IsCrewHuman(medic)
+			and IsCrewHuman(patient)
+			and patient.TeamID == medic.TeamID
+			and NeedsResuscitation(patient)
+			and CloseEnoughToTreat(medic, patient)
+		then
+			StowHeldMedicalItems(medic)
+			pcall(function() medic.SelectedCharacter = patient end)
+			StartCPRAnimation(medic)
+		else
+			ClearBotCPRState(medicKey)
+		end
+	end
+end
+
+function BFA.IsSustainingCPR(medic, patient)
+	if medic == nil then return false end
+	local state = BFA.State.cpr[CharacterKey(medic)]
+	if state == nil then return false end
+	if patient ~= nil and state.patient ~= patient then return false end
+	return IsCrewHuman(state.patient) and NeedsResuscitation(state.patient)
+end
+
+local Policy = {}
+NT.BotEngagementPolicy = Policy
+
+local followOrders = { follow = true }
+local rescueOrders = { rescue = true, requestfirstaid = true }
+local weaponOrders = { operateweapons = true }
+local combatOrders = { fightintruders = true, assaultenemy = true, findweapon = true }
+local repairOrders = {
+	fixleaks = true,
+	repairsystems = true,
+	repairmechanical = true,
+	repairelectrical = true,
+	extinguishfires = true,
+	pumpwater = true,
+}
+local focusOrders = {
+	operateweapons = true,
+	steer = true,
+	fightintruders = true,
+	assaultenemy = true,
+	findweapon = true,
+	fixleaks = true,
+	repairsystems = true,
+	repairmechanical = true,
+	repairelectrical = true,
+	extinguishfires = true,
+	pumpwater = true,
+}
+
+local function IdentifierText(value)
+	if value == nil then return nil end
+	local innerValue = SafeProperty(value, "Value", nil)
+	if innerValue ~= nil then return string.lower(tostring(innerValue)) end
+	return string.lower(tostring(value))
+end
+
+local function ObjectiveIdentifier(objective)
+	return IdentifierText(SafeProperty(objective, "Identifier", nil))
+end
+
+local function OrderIdentifier(order)
+	local identifier = IdentifierText(SafeProperty(order, "Identifier", nil))
+	if identifier ~= nil and identifier ~= "" then return identifier end
+
+	local objective = SafeProperty(order, "Objective", nil)
+	return ObjectiveIdentifier(objective)
+end
+
+local function TypeName(value)
+	if value == nil then return "" end
+	local typeName = ""
+	pcall(function() typeName = tostring(value.GetType().Name) end)
+	return string.lower(typeName)
+end
+
+local function ObjectiveText(objective)
+	if objective == nil then return "" end
+	local text = TypeName(objective)
+	local identifier = ObjectiveIdentifier(objective)
+	if identifier ~= nil then text = text .. " " .. identifier end
+	local debugTag = SafeProperty(objective, "DebugTag", nil)
+	if debugTag ~= nil then text = text .. " " .. string.lower(tostring(debugTag)) end
+	return text
+end
+
+local function ObjectiveMatches(objective, identifiers, patterns)
+	local identifier = ObjectiveIdentifier(objective)
+	if identifier ~= nil and identifiers ~= nil and identifiers[identifier] then return true end
+
+	if patterns ~= nil then
+		local text = ObjectiveText(objective)
+		for _, pattern in ipairs(patterns) do
+			if string.find(text, pattern, 1, true) ~= nil then return true end
+		end
+	end
+
+	return false
+end
+
+local function ObjectivePriority(objective)
+	local priority = SafeProperty(objective, "Priority", nil)
+	if type(priority) == "number" then return priority end
+	return 0
+end
+
+local function GetObjectiveManager(character)
+	local ai = SafeProperty(character, "AIController", nil)
+	return ai ~= nil and SafeProperty(ai, "ObjectiveManager", nil) or nil
+end
+
+local function ForEachCurrentOrder(character, callback)
+	local manager = GetObjectiveManager(character)
+	local orders = manager ~= nil and SafeProperty(manager, "CurrentOrders", nil) or nil
+	if orders == nil then return false end
+
+	local stopped = false
+	local ok = pcall(function()
+		for order in orders do
+			if callback(order) == true then
+				stopped = true
+				break
+			end
+		end
+	end)
+	if ok then return stopped end
+
+	pcall(function()
+		for _, order in pairs(orders) do
+			if callback(order) == true then
+				stopped = true
+				break
+			end
+		end
+	end)
+	return stopped
+end
+
+function Policy.HasOrder(character, identifiers)
+	return ForEachCurrentOrder(character, function(order)
+		local identifier = OrderIdentifier(order)
+		return identifier ~= nil and identifiers[identifier] == true
+	end)
+end
+
+local function HighestOrderPriority(character, identifiers)
+	local highest = nil
+	ForEachCurrentOrder(character, function(order)
+		local identifier = OrderIdentifier(order)
+		if identifier ~= nil and identifiers[identifier] == true then
+			local priority = SafeProperty(order, "ManualPriority", nil)
+			if type(priority) ~= "number" then
+				priority = ObjectivePriority(SafeProperty(order, "Objective", nil))
+			end
+			if highest == nil or priority > highest then highest = priority end
+		end
+		return false
+	end)
+	return highest
+end
+
+local function CurrentObjective(character)
+	local manager = GetObjectiveManager(character)
+	if manager == nil then return nil end
+
+	local objective = nil
+	pcall(function() objective = manager.GetActiveObjective() end)
+	if objective ~= nil then return objective end
+
+	objective = SafeProperty(manager, "CurrentObjective", nil)
+	if objective ~= nil then return objective end
+
+	return SafeProperty(manager, "CurrentOrder", nil)
+end
+
+local function CurrentOrderObjective(character)
+	local manager = GetObjectiveManager(character)
+	if manager == nil then return nil end
+	return SafeProperty(manager, "CurrentOrder", nil)
+end
+
+local function ActiveMatches(character, identifiers, patterns)
+	local objective = CurrentObjective(character)
+	if ObjectiveMatches(objective, identifiers, patterns) then return true end
+
+	local orderObjective = CurrentOrderObjective(character)
+	return ObjectiveMatches(orderObjective, identifiers, patterns)
+end
+
+function Policy.GetDutyState(character)
+	local manager = GetObjectiveManager(character)
+	local activeObjective = CurrentObjective(character)
+	local currentOrder = CurrentOrderObjective(character)
+	local managerPriority = 0
+	if manager ~= nil then
+		pcall(function() managerPriority = manager.GetCurrentPriority() end)
+	end
+	local activePriority = math.max(ObjectivePriority(activeObjective), ObjectivePriority(currentOrder), managerPriority or 0)
+	local activeWeapon = ActiveMatches(character, weaponOrders, { "operateweapons", "turret" })
+	local activeCombat = ActiveMatches(character, combatOrders, { "combat", "fightintruders", "assaultenemy" })
+	local activeRepair = ActiveMatches(character, repairOrders, { "fixleaks", "repair", "extinguish", "pumpwater" })
+	local activeImportant = activePriority <= 0 or activePriority >= 30
+	local rescuePriority = HighestOrderPriority(character, rescueOrders)
+	local focusPriority = HighestOrderPriority(character, focusOrders)
+	local rescueActive = ActiveMatches(character, rescueOrders, { "rescue", "firstaid" })
+	local hasRescue = rescuePriority ~= nil
+
+	return {
+		follow = Policy.HasOrder(character, followOrders),
+		hasRescue = hasRescue,
+		rescueDominant = rescueActive or (hasRescue and (focusPriority == nil or rescuePriority >= focusPriority)),
+		activeWeapon = activeWeapon and activeImportant,
+		activeCombat = activeCombat and activeImportant,
+		activeRepair = activeRepair and activeImportant,
+		activeHighFocus = (activeWeapon or activeCombat or activeRepair) and activeImportant,
+		activePriority = activePriority,
+	}
+end
+
+function Policy.IsCriticalPatient(patient)
+	if patient == nil then return false end
+	if NeedsResuscitation(patient) then return true end
+	if PatientIsIncapacitated(patient) then return true end
+	if BloodLossValue(patient) >= 45 then return true end
+	return PatientTreatmentScore(patient) >= BFA.Settings.selfCareSevereScore
+end
+
+function Policy.HasCarriedQuickTreatment(medic, patient)
+	if medic == nil or medic.Inventory == nil then return false end
+	if PatientNeedsBloodPack(patient) and FindCompatibleBloodPack(medic, patient) ~= nil then return true end
+
+	local limb, score = FindWorstTreatableLimb(patient)
+	if limb == nil or score <= 0 then return false end
+	local limbType = HF ~= nil and HF.NormalizeLimbType ~= nil and HF.NormalizeLimbType(limb.type) or limb.type
+
+	if NeedsWoundClosure(patient, limbType) and GetMedicalSkill(medic) >= 30 and FindInventoryItem(medic, { "suture" }) ~= nil then
+		return true
+	end
+	if NeedsBleedingControl(patient, limbType) and FindInventoryItem(medic, { "antibleeding3", "antibleeding2", "antibleeding1", "bandage" }) ~= nil then
+		return true
+	end
+	return false
+end
+
+function Policy.GetTreatmentMode(medic, patient)
+	if not IsCrewHuman(medic) or not IsBot(medic) or not IsCrewHuman(patient) then return false, "none" end
+	if patient.IsDead or patient.Removed then return false, "none" end
+	if PatientIsIncapacitated(medic) then return false, "unconscious" end
+	local patientDuty = Policy.GetDutyState(patient)
+	if patientDuty.follow then return false, "follow_lock" end
+	if medic ~= patient and patientDuty.activeCombat then return false, "patient_combat" end
+
+	local score = PatientTreatmentScore(patient)
+	local critical = Policy.IsCriticalPatient(patient)
+	local medicDuty = Policy.GetDutyState(medic)
+	local isMedic = IsMedicalJob(medic)
+	local highSkill = GetMedicalSkill(medic) >= BFA.Settings.highSkillMedicalThreshold
+	if medicDuty.follow then return false, "helper_follow" end
+
+	if medic == patient then
+		if medicDuty.activeCombat then return false, "combat" end
+
+		-- Actively manning weapons or repairing: only use items already in hand.
+		if medicDuty.activeWeapon or medicDuty.activeRepair then
+			if critical and score >= BFA.Settings.quickCareMinimumScore and Policy.HasCarriedQuickTreatment(medic, patient) then
+				return true, "quick"
+			end
+			return false, "high_focus"
+		end
+
+		if isMedic or medicDuty.rescueDominant then
+			return score > 0.1, "full"
+		end
+
+		-- The bot has a focus-type order (repair, weapons, combat) but is momentarily
+		-- between sub-tasks. Respect the order intent: only use items already carried
+		-- for minor injuries; allow basic self-care only when the injury is severe.
+		if Policy.HasOrder(medic, focusOrders) then
+			if score >= BFA.Settings.selfCareMinimumScore and Policy.HasCarriedQuickTreatment(medic, patient) then
+				return true, "quick"
+			end
+			if score >= BFA.Settings.selfCareSevereScore then
+				return true, "basic"
+			end
+			return false, "focus_order_self"
+		end
+
+		if score >= BFA.Settings.selfCareMinimumScore then
+			return true, "basic"
+		end
+		return false, "minor_self"
+	end
+
+	if medicDuty.activeCombat and not medicDuty.rescueDominant then return false, "helper_combat" end
+	if medicDuty.activeHighFocus and not medicDuty.rescueDominant then return false, "helper_high_focus" end
+
+	if isMedic then
+		if medicDuty.rescueDominant
+			or critical
+			or score >= BFA.Settings.otherCareMinimumScore
+			or PatientNeedsFunctionalBoneCare(patient)
+		then
+			return true, "full"
+		end
+		return false, "minor_other"
+	end
+
+	if medicDuty.rescueDominant and (score >= BFA.Settings.otherCareMinimumScore or PatientNeedsFunctionalBoneCare(patient)) then
+		return true, "basic"
+	end
+
+	if highSkill and not medicDuty.activeHighFocus and (critical or PatientIsIncapacitated(patient) or score >= BFA.Settings.nonMedicHelperMinimumScore) then
+		return true, "basic"
+	end
+
+	return false, "not_medic"
+end
+
+local function TryBotCPR(medic, patient)
+	if medic == patient or not NeedsResuscitation(patient) then return false end
+	local medicKey = CharacterKey(medic)
+	if patient.IsDead or patient.Removed then
+		ClearBotCPRState(medicKey)
+		return false
+	end
+
+	local state = BFA.State.cpr[medicKey]
+	if state == nil or state.patient ~= patient then
+		ClearBotCPRState(medicKey)
+		state = {
+			medic = medic,
+			patient = patient,
+			patientKey = CharacterKey(patient),
+			ticks = 0,
+		}
+		BFA.State.cpr[medicKey] = state
+		StowHeldMedicalItems(medic)
+		Log(CharacterName(medic) .. " started CPR on " .. CharacterName(patient))
+	end
+
+	pcall(function() medic.SelectedCharacter = patient end)
+	StartCPRAnimation(medic)
+	RefreshBotCPRBuffs(medic, patient)
+
+	state.ticks = state.ticks + BFA.Settings.assistIntervalTicks
+	return true
+end
+
+local function SelectBasicFallbackItem(medic, patient, limbType)
+	if NeedsWoundClosure(patient, limbType) and GetMedicalSkill(medic) >= 30 then
+		local suture = FindInventoryItem(medic, { "suture" })
+		if suture ~= nil then return suture end
+	end
+
+	if NeedsBleedingControl(patient, limbType) then
+		local nonstop = GetAfflictionLimb(patient, limbType, "bleedingnonstop", 0)
+		local bandaged = GetAfflictionLimb(patient, limbType, "bandaged", 0)
+		local softCap = IsMedicalJob(medic) and 50 or 30
+		if bandaged < softCap or nonstop > 0.1 then
+			local bandage = FindInventoryItem(medic, { "antibleeding3", "antibleeding2", "antibleeding1", "bandage" })
+			if bandage ~= nil then return bandage end
+		end
+	end
+
+	return nil
+end
+
+local function TryCarriedCleanupTemporaryTreatment(medic, patient)
+	local limb, limbType = FindCleanupLimb(patient)
+	if limb == nil or limbType == nil then return false end
+
+	local item = nil
+	if GetAfflictionLimb(patient, limbType, "gypsumcast", 0) <= 0.1 then
+		item = FindInventoryItem(medic, { "traumashears" })
+	end
+	if item == nil and GetMedicalSkill(medic) >= 30 then
+		item = FindInventoryItem(medic, { "divingknife" })
+	end
+	if item == nil then return false end
+
+	return ApplyItem(item, medic, patient, limb)
+end
+
+local function TryBasicCarriedTreatment(medic, patient, allowCleanup)
+	local bloodPack = FindCompatibleBloodPack(medic, patient)
+	if bloodPack ~= nil and PatientNeedsBloodPack(patient) then
+		local torso = LimbObject(patient, LimbType.Torso)
+		if torso ~= nil then return ApplyItem(bloodPack, medic, patient, torso) end
+	end
+
+	local limb, score = FindWorstTreatableLimb(patient)
+	if limb ~= nil and score > 0 then
+		local limbType = HF ~= nil and HF.NormalizeLimbType ~= nil and HF.NormalizeLimbType(limb.type) or limb.type
+		local item = SelectBasicFallbackItem(medic, patient, limbType)
+		if item ~= nil then return ApplyItem(item, medic, patient, limb) end
+	end
+
+	if allowCleanup then
+		return TryCarriedCleanupTemporaryTreatment(medic, patient)
+	end
+
+	return false
+end
+
+local function TryHigherPriorityTreatmentBeforeBoneCare(medic, patient)
+	if BloodLossValue(patient) >= 45 then
+		local systemicItem = SelectSystemicFallbackItem(medic, patient)
+		local torso = LimbObject(patient, LimbType.Torso)
+		if systemicItem ~= nil and torso ~= nil then
+			return ApplyItem(systemicItem, medic, patient, torso)
+		end
+		for _, identifier in ipairs(bloodPackIdentifiers) do
+			if FindAvailableWorldItem(identifier, medic, nil) ~= nil then
+				RequestMedicalItem(medic, bloodPackIdentifiers, 9, medic == patient)
+				return true
+			end
+		end
+	end
+
+	for _, limbType in ipairs(limbTypes) do
+		local limb = LimbObject(patient, limbType)
+		if limb ~= nil then
+			local bleeding = GetAfflictionLimb(patient, limbType, "bleeding", 0)
+			local nonstop = GetAfflictionLimb(patient, limbType, "bleedingnonstop", 0)
+			local sutured = GetAfflictionLimb(patient, limbType, "suturedw", 0)
+
+			if NeedsWoundClosure(patient, limbType)
+				and sutured <= 0.1
+				and (nonstop > 0.1 or bleeding > 1)
+				and GetMedicalSkill(medic) >= 30
+			then
+				local suture = FindInventoryItem(medic, { "suture" })
+				if suture ~= nil then return ApplyItem(suture, medic, patient, limb) end
+				if FindAvailableWorldItem("suture", medic, nil) ~= nil then
+					RequestMedicalItem(medic, { "suture" }, 9, medic == patient)
+					return true
+				end
+			end
+
+			if NeedsBleedingControl(patient, limbType) then
+				local bandage = FindInventoryItem(medic, { "antibleeding3", "antibleeding2", "antibleeding1", "bandage" })
+				if bandage ~= nil then return ApplyItem(bandage, medic, patient, limb) end
+				for _, identifier in ipairs({ "antibleeding1", "bandage", "antibleeding2", "antibleeding3" }) do
+					if FindAvailableWorldItem(identifier, medic, nil) ~= nil then
+						RequestMedicalItem(medic, { "antibleeding1", "bandage", "antibleeding2", "antibleeding3" }, 9, medic == patient)
+						return true
+					end
+				end
+			end
+		end
+	end
+
+	return false
+end
+
+local function RequestSelfCareItem(medic, patient)
+	if medic ~= patient then return false end
+	AddVanillaSelfCareObjective(medic, 1.25)
+
+	if PatientNeedsBloodPack(patient) and FindCompatibleBloodPack(medic, patient) == nil then
+		RequestMedicalItem(medic, bloodPackIdentifiers, 6, true)
+		return false
+	end
+
+	local limb, score = FindWorstTreatableLimb(patient)
+	if limb ~= nil and score > 0 then
+		local limbType = HF ~= nil and HF.NormalizeLimbType ~= nil and HF.NormalizeLimbType(limb.type) or limb.type
+		if NeedsBleedingControl(patient, limbType)
+			and FindInventoryItem(medic, { "antibleeding3", "antibleeding2", "antibleeding1", "bandage" }) == nil
+		then
+			RequestMedicalItem(medic, { "antibleeding1", "bandage", "antibleeding2", "antibleeding3" }, 6, true)
+			return false
+		end
+		if NeedsWoundClosure(patient, limbType)
+			and GetMedicalSkill(medic) >= 30
+			and FindInventoryItem(medic, { "suture" }) == nil
+		then
+			RequestMedicalItem(medic, { "suture" }, 6, true)
+			return false
+		end
+	end
+
+	if PatientNeedsBandage(patient)
+		and FindInventoryItem(medic, { "antibleeding3", "antibleeding2", "antibleeding1", "bandage" }) == nil
+	then
+		RequestMedicalItem(medic, { "antibleeding1", "bandage", "antibleeding2", "antibleeding3" }, 6, true)
+		return false
+	end
+
+	return false
+end
+
+local function HasImmediateWoundClosureOption(medic, patient)
+	if GetMedicalSkill(medic) < 30 or FindInventoryItem(medic, { "suture" }) == nil then return false end
+	for _, limbType in ipairs(limbTypes) do
+		if NeedsWoundClosure(patient, limbType) then return true end
+	end
+	return false
+end
+
+local function HasImmediateBoneCareOption(medic, patient)
+	for _, limbType in ipairs(limbTypes) do
+		if LimbIsExtremity(limbType) and SelectFractureItem(medic, patient, limbType) ~= nil then return true end
+	end
+
+	local hasHigherPriority = PatientHasActionableHigherPriorityThanBoneCare(medic, patient, false)
+	if not hasHigherPriority and BotCanRelocateDislocation(medic, patient) then
+		local _, limbType = FindDislocatedLimb(patient)
+		if limbType ~= nil and SelectDislocationItem(medic, patient, limbType) ~= nil then return true end
+	end
+
+	return false
+end
+
+local function ReleasePatientIfNoImmediateCare(medic, patient)
+	if medic == nil or patient == nil or medic == patient then return end
+	if not IsSelectedPatient(medic, patient) then return end
+	if PatientHasUnstableEmergency(patient) then return end
+	if PatientNeedsBloodPack(patient) then return end
+	if PatientNeedsBandage(patient) then return end
+	if HasImmediateBoneCareOption(medic, patient) then return end
+	if HasImmediateWoundClosureOption(medic, patient) then return end
+
+	local cleanupLimb = FindCleanupLimb(patient)
+	if cleanupLimb ~= nil then return end
+
+	local foreignBodyLimb = FindForeignBodyLimb(patient)
+	if foreignBodyLimb ~= nil then return end
+
+	StowHeldMedicalItems(medic)
+	pcall(function() medic.DeselectCharacter() end)
+	pcall(function() medic.SelectedCharacter = nil end)
+end
+
+local function TryFallbackTreatment(medic, patient)
+	if not IsCrewHuman(medic) or not IsBot(medic) or not IsCrewHuman(patient) then return false end
+	if patient.IsDead or patient.Removed then return false end
+	if medic ~= patient then
+		if not CloseEnoughToTreat(medic, patient) then return false end
+		if not IsSelectedPatient(medic, patient)
+			and not (NeedsResuscitation(patient) and BFA.IsSustainingCPR(medic, patient))
+		then
+			if PatientNeedsFunctionalBoneCare(patient)
+				and (IsMedicalJob(medic) or GetMedicalSkill(medic) >= BFA.Settings.highSkillMedicalThreshold)
+			then
+				pcall(function() medic.SelectedCharacter = patient end)
+			else
+				return false
+			end
+		end
+	end
+
+	local allowed, treatmentMode = Policy.GetTreatmentMode(medic, patient)
+	if not allowed then return false end
+	if medic == patient then AddVanillaSelfCareObjective(medic, 1.25) end
+
+	if treatmentMode == "quick" then
+		return TryBasicCarriedTreatment(medic, patient, false)
+	end
+
+	if treatmentMode == "basic" then
+		if medic ~= patient and NeedsResuscitation(patient) then
+			if IsMedicalJob(medic) or GetMedicalSkill(medic) >= BFA.Settings.highSkillMedicalThreshold then
+				return TryBotCPR(medic, patient)
+			end
+			return false
+		end
+		if TryBasicCarriedTreatment(medic, patient, true) then return true end
+		if medic == patient then
+			if TryCleanupTemporaryTreatment(medic, patient) then return true end
+			return RequestSelfCareItem(medic, patient)
+		end
+		return false
+	end
+
+	if medic ~= patient and NeedsResuscitation(patient) then
+		return TryBotCPR(medic, patient)
+	end
+
+	local heldBloodPack = FindHeldCompatibleBloodPack(medic, patient)
+	if heldBloodPack ~= nil and PatientCanUseHeldBloodPack(patient) then
+		local torso = LimbObject(patient, LimbType.Torso)
+		if torso ~= nil then return ApplyItem(heldBloodPack, medic, patient, torso) end
+	end
+
+	StowStaleHeldBandage(medic, patient)
+	StowStaleHeldBoneItems(medic, patient)
+
+	if BloodLossValue(patient) >= 45 then
+		local systemicItem = SelectSystemicFallbackItem(medic, patient)
+		local torso = LimbObject(patient, LimbType.Torso)
+		if systemicItem ~= nil and torso ~= nil then
+			return ApplyItem(systemicItem, medic, patient, torso)
+		end
+	end
+
+	if TryForeignBodyRemoval(medic, patient) then return true end
+	if TryHigherPriorityTreatmentBeforeBoneCare(medic, patient) then return true end
+
+	local limb, score = FindWorstTreatableLimb(patient)
+	local item = nil
+	if limb ~= nil and score > 0 then
+		local limbType = HF ~= nil and HF.NormalizeLimbType ~= nil and HF.NormalizeLimbType(limb.type) or limb.type
+		item = SelectFallbackItem(medic, patient, limbType)
+	end
+
+	if item ~= nil and limb ~= nil then
+		return ApplyItem(item, medic, patient, limb)
+	end
+
+	if TrySequentialProcedure(medic, patient, "fracture_cast") then return true end
+	if TryDislocationTreatment(medic, patient) then return true end
+	if TryCleanupTemporaryTreatment(medic, patient) then return true end
+
+	if item == nil then
+		limb = LimbObject(patient, LimbType.Torso)
+		item = SelectSystemicFallbackItem(medic, patient)
+	end
+
+	if item == nil or limb == nil then
+		if medic == patient and RequestSelfCareItem(medic, patient) then return true end
+		ReleasePatientIfNoImmediateCare(medic, patient)
+		return false
+	end
+
+	return ApplyItem(item, medic, patient, limb)
+end
+
+local function CharacterInjuryScore(character)
+	return PatientTreatmentScore(character)
+end
+
+local function FindBestFallbackPatient(medic)
+	local cprState = BFA.State.cpr[CharacterKey(medic)]
+	if cprState ~= nil
+		and IsCrewHuman(cprState.patient)
+		and cprState.patient.TeamID == medic.TeamID
+		and NeedsResuscitation(cprState.patient)
+		and CloseEnoughToTreat(medic, cprState.patient)
+	then
+		local allowed = Policy.GetTreatmentMode(medic, cprState.patient)
+		if allowed then return cprState.patient end
+	end
+
+	local selected = SafeProperty(medic, "SelectedCharacter", nil)
+	if IsCrewHuman(selected) and selected.TeamID == medic.TeamID and CharacterInjuryScore(selected) > 0 then
+		local allowed = Policy.GetTreatmentMode(medic, selected)
+		if allowed then return selected end
+	end
+
+	local bestPatient = nil
+	local bestScore = 0
+	if Character == nil or Character.CharacterList == nil then return nil end
+
+	local medicDuty = Policy.GetDutyState(medic)
+	local canHelpOthers = IsMedicalJob(medic)
+		or GetMedicalSkill(medic) >= BFA.Settings.highSkillMedicalThreshold
+		or (medicDuty ~= nil and medicDuty.rescueDominant == true)
+	if canHelpOthers then
+		for _, patient in pairs(Character.CharacterList) do
+			if IsCrewHuman(patient) and patient.TeamID == medic.TeamID and patient ~= medic then
+				local score = CharacterInjuryScore(patient)
+				local boneScore = PatientFunctionalBoneScore(patient)
+				local allowed = Policy.GetTreatmentMode(medic, patient)
+				local eligible = score >= BFA.Settings.otherCareMinimumScore
+					or (boneScore > 0 and score <= BFA.Settings.otherCareMinimumScore)
+				if allowed and CloseEnoughToTreat(medic, patient) and eligible then
+					local selectionScore = score
+					if score <= BFA.Settings.otherCareMinimumScore then
+						selectionScore = selectionScore + math.min(boneScore, 20)
+					end
+					if selectionScore > bestScore then
+						bestPatient = patient
+						bestScore = selectionScore
+					end
+				end
+			end
+		end
+		if bestPatient ~= nil then return bestPatient end
+	end
+
+	for _, patient in pairs(Character.CharacterList) do
+		if IsCrewHuman(patient) and patient.TeamID == medic.TeamID and patient == medic then
+			local score = CharacterInjuryScore(patient)
+			local allowed = Policy.GetTreatmentMode(medic, patient)
+			local stabilizedPause = HasCooldown(BFA.State.stabilizedCooldowns, CharacterKey(patient))
+				and not PatientHasUnstableEmergency(patient)
+				and score < BFA.Settings.selfCareSevereScore
+			if allowed and not stabilizedPause and score > bestScore then
+				bestPatient = patient
+				bestScore = score
+			end
+		end
+	end
+
+	return bestPatient
+end
+
+local function TrySetTreatmentSuitability(itemIdentifier, afflictionIdentifier, suitability)
+	if ItemPrefab == nil or Identifier == nil then return false end
+
+	local ok, changed = pcall(function()
+		local prefab = ItemPrefab.GetItemPrefab(itemIdentifier)
+		if prefab == nil or prefab.TreatmentSuitabilities == nil then return false end
+		prefab.TreatmentSuitabilities[Identifier(afflictionIdentifier)] = suitability
+		return true
+	end)
+	if ok and changed then return true end
+
+	ok, changed = pcall(function()
+		local prefab = ItemPrefab.GetItemPrefab(itemIdentifier)
+		if prefab == nil or prefab.TreatmentSuitabilities == nil then return false end
+		prefab.TreatmentSuitabilities[afflictionIdentifier] = suitability
+		return true
+	end)
+
+	return ok and changed == true
+end
+
+local treatmentVocabulary = {
+	-- Bleeding and wound closure.
+	suture = {
+		bleeding = 35,
+		bleedingnonstop = 110,
+		lacerations = 135,
+		bitewounds = 125,
+		gunshotwound = 140,
+		explosiondamage = 130,
+		surgeryincision = 160,
+	},
+	antibleeding1 = {
+		bleeding = 75,
+		bleedingnonstop = 20,
+		lacerations = 55,
+		bitewounds = 45,
+		gunshotwound = 55,
+		explosiondamage = 45,
+		ll_fracture = 45,
+		rl_fracture = 45,
+		la_fracture = 45,
+		ra_fracture = 45,
+	},
+	bandage = {
+		bleeding = 75,
+		bleedingnonstop = 20,
+		lacerations = 55,
+		bitewounds = 45,
+		gunshotwound = 55,
+		explosiondamage = 45,
+		ll_fracture = 45,
+		rl_fracture = 45,
+		la_fracture = 45,
+		ra_fracture = 45,
+	},
+	antibleeding2 = {
+		bleeding = 75,
+		bleedingnonstop = 30,
+		lacerations = 70,
+		bitewounds = 60,
+		gunshotwound = 70,
+		explosiondamage = 60,
+		burn = 45,
+		infectedwound = 15,
+	},
+	antibleeding3 = {
+		bleeding = 85,
+		bleedingnonstop = 35,
+		lacerations = 80,
+		bitewounds = 70,
+		gunshotwound = 80,
+		explosiondamage = 70,
+		burn = 60,
+		infectedwound = 80,
+	},
+	tourniquet = {
+		ll_arterialcut = 110,
+		rl_arterialcut = 110,
+		la_arterialcut = 110,
+		ra_arterialcut = 110,
+		bleedingnonstop = 70,
+		h_arterialcut = -80,
+		t_arterialcut = -80,
+	},
+	tweezers = {
+		foreignbody = 85,
+		gunshotwound = 15,
+		explosiondamage = 15,
+	},
+
+	-- Removing temporary treatment that can become harmful later.
+	traumashears = {
+		dirtybandage = 120,
+		arteriesclamp = 95,
+		bandaged = 15,
+		gypsumcast = 10,
+	},
+	divingknife = {
+		dirtybandage = 65,
+		arteriesclamp = 55,
+		bandaged = 10,
+	},
+
+	-- Fractures and dislocations. Kept intentionally lower than life-saving care.
+	gypsum = {
+		ll_fracture = 115,
+		rl_fracture = 115,
+		la_fracture = 115,
+		ra_fracture = 115,
+	},
+	wrench = {
+		dislocation1 = 20,
+		dislocation2 = 20,
+		dislocation3 = 20,
+		dislocation4 = 20,
+	},
+	heavywrench = {
+		dislocation1 = 25,
+		dislocation2 = 25,
+		dislocation3 = 25,
+		dislocation4 = 25,
+	},
+	repairpack = {
+		dislocation1 = 25,
+		dislocation2 = 25,
+		dislocation3 = 25,
+		dislocation4 = 25,
+	},
+
+	-- Circulation, oxygenation and resuscitation.
+	antibloodloss1 = {
+		bloodloss = 75,
+		bloodpressure = 55,
+	},
+	ringerssolution = {
+		bloodloss = 95,
+		bloodpressure = 85,
+		hypoxemia = 25,
+		acidosis = 20,
+		alkalosis = 20,
+	},
+	-- Blood bags are useful in severe bloodloss, but lower than Ringer/saline so bots
+	-- do not waste them on mild cases.
+	antibloodloss2 = {
+		bloodloss = 80,
+		bloodpressure = 65,
+		hemotransfusionshock = -100,
+	},
+	bloodpackominus = {
+		bloodloss = 80,
+		bloodpressure = 65,
+	},
+	bloodpackoplus = {
+		bloodloss = 55,
+		bloodpressure = 45,
+	},
+	bloodpackaminus = {
+		bloodloss = 55,
+		bloodpressure = 45,
+	},
+	bloodpackaplus = {
+		bloodloss = 55,
+		bloodpressure = 45,
+	},
+	bloodpackbminus = {
+		bloodloss = 55,
+		bloodpressure = 45,
+	},
+	bloodpackbplus = {
+		bloodloss = 55,
+		bloodpressure = 45,
+	},
+	bloodpackabminus = {
+		bloodloss = 55,
+		bloodpressure = 45,
+	},
+	bloodpackabplus = {
+		bloodloss = 55,
+		bloodpressure = 45,
+	},
+	bvm = {
+		respiration = 40,
+		oxygenlow = 105,
+		hypoxemia = 95,
+		respiratoryarrest = 105,
+		cardiacarrest = 25,
+	},
+	liquidoxygenite = {
+		oxygenlow = 100,
+		hypoxemia = 100,
+		cerebralhypoxia = 35,
+		respiratoryarrest = 70,
+	},
+	autocpr = {
+		cardiacarrest = 115,
+		respiratoryarrest = 85,
+		oxygenlow = 40,
+	},
+	adrenaline = {
+		cardiacarrest = 125,
+		bloodpressure = 35,
+		sym_unconsciousness = 15,
+	},
+	aed = {
+		cardiacarrest = 120,
+		fibrillation = 125,
+		tachycardia = 60,
+	},
+	defibrillator = {
+		cardiacarrest = 110,
+		fibrillation = 115,
+		tachycardia = 55,
+	},
+
+	-- Other first-aid level Neurotrauma items.
+	needle = {
+		pneumothorax = 100,
+		tamponade = 75,
+	},
+	ointment = {
+		burn = 70,
+		burn_deg1 = 80,
+		burn_deg2 = 65,
+		infectedwound = 85,
+	},
+	gelipack = {
+		blunttrauma = 65,
+		inflammation = -100,
+		infectedwound = -100,
+	},
+	antibiotics = {
+		infectedwound = 70,
+		sepsis = 100,
+	},
+	antinarc = {
+		opiateoverdose = 110,
+		opiateaddiction = -40,
+	},
+	streptokinase = {
+		heartattack = 95,
+		hemotransfusionshock = 40,
+		stroke = -100,
+	},
+	stabilozine = {
+		heartattack = 55,
+		hemotransfusionshock = 35,
+	},
+	mannitol = {
+		cerebralhypoxia = 45,
+	},
+}
+
+local discouragedBotTreatments = {
+	aed = {
+		cardiacarrest = -1000,
+		fibrillation = -1000,
+		tachycardia = -1000,
+	},
+	defibrillator = {
+		cardiacarrest = -1000,
+		fibrillation = -1000,
+		tachycardia = -1000,
+	},
+	autocpr = {
+		cardiacarrest = -1000,
+		respiratoryarrest = -1000,
+		oxygenlow = -1000,
+	},
+	bvm = {
+		cardiacarrest = -1000,
+		respiratoryarrest = -1000,
+		oxygenlow = -1000,
+		hypoxemia = -1000,
+	},
+	advscalpel = { sym_unconsciousness = -100, analgesia = -100 },
+	multiscalpel = { sym_unconsciousness = -100, analgesia = -100 },
+	advhemostat = { bleeding = -25, bleedingnonstop = -25 },
+	advretractors = { sym_unconsciousness = -100, analgesia = -100 },
+	surgicaldrill = { ll_fracture = -100, rl_fracture = -100, la_fracture = -100, ra_fracture = -100 },
+	surgerysaw = { ll_fracture = -100, rl_fracture = -100, la_fracture = -100, ra_fracture = -100 },
+	tweezers = { bleeding = -20, dirtybandage = -20 },
+	osteosynthesisimplants = { ll_fracture = -100, rl_fracture = -100, la_fracture = -100, ra_fracture = -100 },
+	spinalimplant = { t_paralysis = -100 },
+}
+
+local function InstallVocabulary()
+	if BFA.State.vanillaVocabularyInstalled then return end
+	BFA.State.vanillaVocabularyInstalled = true
+
+	if NTConfig ~= nil and NTConfig.Set ~= nil then
+		NTConfig.Set("NT_disableBotAlgorithms", false)
+	end
+
+	local changed = 0
+	for itemIdentifier, treatments in pairs(treatmentVocabulary) do
+		for afflictionIdentifier, suitability in pairs(treatments) do
+			if TrySetTreatmentSuitability(itemIdentifier, afflictionIdentifier, suitability) then
+				changed = changed + 1
+			end
+		end
+	end
+
+	for itemIdentifier, treatments in pairs(discouragedBotTreatments) do
+		for afflictionIdentifier, suitability in pairs(treatments) do
+			if TrySetTreatmentSuitability(itemIdentifier, afflictionIdentifier, suitability) then
+				changed = changed + 1
+			end
+		end
+	end
+
+	Log("installed vanilla bot treatment vocabulary entries: " .. tostring(changed))
+end
+
+InstallVocabulary()
+
+BFA.ThinkCooldown = BFA.Settings.assistIntervalTicks
+Hook.Add("think", "NT.BotFirstAid.Assist", function()
+	if Game ~= nil and not Game.RoundStarted then return end
+	if Character == nil or Character.CharacterList == nil then return end
+
+	MaintainBotCPRStates()
+
+	BFA.ThinkCooldown = BFA.ThinkCooldown - 1
+	if BFA.ThinkCooldown > 0 then return end
+	BFA.ThinkCooldown = BFA.Settings.assistIntervalTicks
+
+	TickCooldowns(BFA.State.actionCooldowns)
+	TickCooldowns(BFA.State.botCooldowns)
+	TickCooldowns(BFA.State.itemRequests)
+	TickCooldowns(BFA.State.stabilizedCooldowns)
+	CleanupBotCPRStates()
+	RefreshMedicalItemObjectives()
+	RefreshSelfCareObjectives()
+
+	local actions = 0
+	for _, medic in pairs(Character.CharacterList) do
+		if actions >= BFA.Settings.maxActionsPerTick then break end
+		if IsCrewHuman(medic) and IsBot(medic) and not PatientIsIncapacitated(medic) then
+			StowForbiddenComplexMedicalEquipment(medic)
+			if ProcessMedicalItemFetch(medic) then
+				actions = actions + 1
+			else
+				local patient = FindBestFallbackPatient(medic)
+				if patient ~= nil then
+					local actionKey = CooldownKey(medic, CharacterKey(patient))
+					local bypassCooldown = medic ~= patient and NeedsResuscitation(patient)
+					if (bypassCooldown or not HasCooldown(BFA.State.botCooldowns, CharacterKey(medic)))
+						and (bypassCooldown or not HasCooldown(BFA.State.actionCooldowns, actionKey))
+					then
+						if TryFallbackTreatment(medic, patient) then
+							SetCooldown(BFA.State.actionCooldowns, actionKey, BFA.Settings.actionCooldownTicks)
+							SetCooldown(BFA.State.botCooldowns, CharacterKey(medic), BFA.Settings.botCooldownTicks)
+							if medic == patient and not PatientHasUnstableEmergency(patient) then
+								SetCooldown(BFA.State.stabilizedCooldowns, CharacterKey(patient), BFA.Settings.stabilizedCooldownTicks)
+							end
+							actions = actions + 1
+						elseif not bypassCooldown then
+							-- Nothing to do for this patient right now. Set a cooldown so the bot
+							-- does not spin re-evaluating the same treated patient every tick
+							-- (especially visible when the bot has a manual rescue order active).
+							SetCooldown(BFA.State.actionCooldowns, actionKey, BFA.Settings.actionCooldownTicks)
+						end
+					end
+				else
+					ClearSelfCareObjective(CharacterKey(medic))
+					ReturnBorrowedSpecialtyTools(medic)
+				end
+			end
+		end
+	end
+end)
+
+Hook.Add("roundStart", "NT.BotFirstAid.AssistRoundStart", function()
+	BFA.State.actionCooldowns = {}
+	BFA.State.botCooldowns = {}
+	BFA.State.procedures = {}
+	BFA.State.itemRequests = {}
+	BFA.State.itemObjectives = {}
+	BFA.State.itemFetches = {}
+	BFA.State.selfCareObjectives = {}
+	BFA.State.stabilizedCooldowns = {}
+	BFA.State.cpr = {}
+end)

--- a/Neurotrauma/Lua/Scripts/Server/botinitiative.lua
+++ b/Neurotrauma/Lua/Scripts/Server/botinitiative.lua
@@ -1,0 +1,527 @@
+if Hook ~= nil and Hook.Remove ~= nil then
+	pcall(function() Hook.Remove("think", "NT.BotInitiative.Think") end)
+	pcall(function() Hook.Remove("roundStart", "NT.BotInitiative.RoundStart") end)
+end
+
+NT.BotInitiative = { State = { cooldowns = {}, claims = {}, handling = {} } }
+
+local BI = NT.BotInitiative
+BI.Settings = {
+	intervalTicks = 60,
+	cooldownTicks = 180,
+	claimTicks = 420,
+	handlingGraceTicks = 480,
+	criticalHandlingGraceTicks = 120,
+	criticalRetryCooldownTicks = 120,
+	fractureBandageThreshold = 35,
+	highMedicalSkill = 45,
+	criticalScore = 25,
+	selfCareMinimumScore = 16,
+}
+
+local limbTypes = {
+	LimbType.Torso,
+	LimbType.Head,
+	LimbType.LeftArm,
+	LimbType.RightArm,
+	LimbType.LeftLeg,
+	LimbType.RightLeg,
+}
+
+local function SafeProperty(value, propertyName, fallback)
+	if value == nil then return fallback end
+	local ok, result = pcall(function() return value[propertyName] end)
+	if ok then return result end
+	return fallback
+end
+
+local function IsBot(character)
+	if character == nil then return false end
+	local isBot = SafeProperty(character, "IsBot", nil)
+	if isBot ~= nil then return isBot == true end
+	return SafeProperty(character, "AIController", nil) ~= nil and SafeProperty(character, "IsPlayer", false) ~= true
+end
+
+local function IsCrewHuman(character)
+	return character ~= nil
+		and not character.Removed
+		and character.IsHuman
+		and not character.IsDead
+		and (character.TeamID == 1 or character.TeamID == 2)
+end
+
+local function IsMedicalJob(character)
+	local isMedic = SafeProperty(character, "IsMedic", nil)
+	if isMedic ~= nil then return isMedic == true end
+
+	local info = SafeProperty(character, "Info", nil)
+	local job = info ~= nil and SafeProperty(info, "Job", nil) or nil
+	local prefab = job ~= nil and SafeProperty(job, "Prefab", nil) or nil
+	local identifier = prefab ~= nil and SafeProperty(prefab, "Identifier", nil) or nil
+	local value = identifier ~= nil and SafeProperty(identifier, "Value", tostring(identifier)) or ""
+	return value == "medicaldoctor" or value == "doctor" or value == "medic"
+end
+
+local function MedicalSkill(character)
+	if HF ~= nil and HF.GetSkillLevel ~= nil then return HF.GetSkillLevel(character, "medical") end
+	return IsMedicalJob(character) and 50 or 10
+end
+
+local function GetAffliction(character, identifier, fallback)
+	if HF ~= nil and HF.GetAfflictionStrength ~= nil then return HF.GetAfflictionStrength(character, identifier, fallback or 0) end
+	return fallback or 0
+end
+
+local function GetAfflictionLimb(character, limbType, identifier, fallback)
+	if HF ~= nil and HF.GetAfflictionStrengthLimb ~= nil then
+		return HF.GetAfflictionStrengthLimb(character, limbType, identifier, fallback or 0)
+	end
+	return fallback or 0
+end
+
+local function Clamp(value, minimum, maximum)
+	if value < minimum then return minimum end
+	if value > maximum then return maximum end
+	return value
+end
+
+local function LimbIsExtremity(limbType)
+	if HF ~= nil and HF.LimbIsExtremity ~= nil then return HF.LimbIsExtremity(limbType) end
+	return limbType == LimbType.LeftArm
+		or limbType == LimbType.RightArm
+		or limbType == LimbType.LeftLeg
+		or limbType == LimbType.RightLeg
+end
+
+local function LimbIsBroken(character, limbType)
+	if NT ~= nil and NT.LimbIsBroken ~= nil then return NT.LimbIsBroken(character, limbType) end
+	return false
+end
+
+local function LimbIsDislocated(character, limbType)
+	if NT ~= nil and NT.LimbIsDislocated ~= nil then return NT.LimbIsDislocated(character, limbType) end
+	return false
+end
+
+local function CharacterKey(character)
+	return tostring(character ~= nil and (character.ID or character.Name) or "nil")
+end
+
+local function CooldownKey(character, suffix)
+	return CharacterKey(character) .. ":" .. tostring(suffix)
+end
+
+local function TickCooldowns()
+	for key, value in pairs(BI.State.cooldowns) do
+		value = value - BI.Settings.intervalTicks
+		if value <= 0 then
+			BI.State.cooldowns[key] = nil
+		else
+			BI.State.cooldowns[key] = value
+		end
+	end
+	for key, value in pairs(BI.State.claims) do
+		value.ticks = value.ticks - BI.Settings.intervalTicks
+		if value.ticks <= 0 then
+			BI.State.claims[key] = nil
+		end
+	end
+end
+
+local function HasCooldown(key)
+	return BI.State.cooldowns[key] ~= nil and BI.State.cooldowns[key] > 0
+end
+
+local function SetCooldown(key)
+	BI.State.cooldowns[key] = BI.Settings.cooldownTicks
+end
+
+local function SetCooldownTicks(key, ticks)
+	BI.State.cooldowns[key] = ticks
+end
+
+local function PatientKey(patient)
+	return CharacterKey(patient)
+end
+
+local function ClaimPatient(helper, patient)
+	if helper == nil or patient == nil then return end
+	BI.State.claims[PatientKey(patient)] = {
+		helper = CharacterKey(helper),
+		ticks = BI.Settings.claimTicks,
+	}
+end
+
+local function IsClaimedByOther(helper, patient)
+	local claim = BI.State.claims[PatientKey(patient)]
+	if claim == nil then return false end
+	return claim.helper ~= CharacterKey(helper)
+end
+
+local function PatientFunctionalBoneScore(patient)
+	local score = 0
+	local affectedLimbs = 0
+	for _, limbType in ipairs(limbTypes) do
+		if LimbIsExtremity(limbType) then
+			local limbAffected = false
+			if LimbIsBroken(patient, limbType) and GetAfflictionLimb(patient, limbType, "gypsumcast", 0) <= 0.1 then
+				score = score + 45
+				limbAffected = true
+			end
+			if LimbIsDislocated(patient, limbType) then
+				score = score + 35
+				limbAffected = true
+			end
+			if limbAffected then affectedLimbs = affectedLimbs + 1 end
+		end
+	end
+
+	if affectedLimbs >= 2 then score = score + 35 end
+	if affectedLimbs >= 3 then score = score + 35 end
+	return score
+end
+
+local function IsCriticalPatient(patient)
+	return patient ~= nil
+		and not patient.Removed
+		and not patient.IsDead
+		and (GetAffliction(patient, "cardiacarrest", 0) > 0.1
+			or GetAffliction(patient, "respiratoryarrest", 0) > 0.1
+			or GetAffliction(patient, "oxygenlow", 0) > 40
+			or GetAffliction(patient, "hypoxemia", 0) > 40)
+end
+
+local function GetTreatmentPolicy()
+	return NT ~= nil and NT.BotEngagementPolicy or nil
+end
+
+local function CanTreat(helper, patient)
+	local policy = GetTreatmentPolicy()
+	if policy == nil or policy.GetTreatmentMode == nil then return true, "legacy" end
+
+	local ok, allowed, mode = pcall(function()
+		local canTreat, treatmentMode = policy.GetTreatmentMode(helper, patient)
+		return canTreat, treatmentMode
+	end)
+	if not ok then return true, "legacy_error" end
+	return allowed == true, mode
+end
+
+local function IsFollowLocked(patient)
+	local policy = GetTreatmentPolicy()
+	if policy == nil or policy.GetDutyState == nil then return false end
+
+	local ok, state = pcall(function() return policy.GetDutyState(patient) end)
+	return ok and state ~= nil and state.follow == true
+end
+
+local function IsFetchingMedicalItem(bot)
+	return NT ~= nil
+		and NT.BotFirstAid ~= nil
+		and NT.BotFirstAid.IsFetchingMedicalItem ~= nil
+		and NT.BotFirstAid.IsFetchingMedicalItem(bot) == true
+end
+
+local function DeselectCharacter(bot)
+	pcall(function() bot.DeselectCharacter() end)
+	pcall(function() bot.SelectedCharacter = nil end)
+end
+
+local function InjuryScore(character)
+	local score = GetAffliction(character, "cardiacarrest", 0) * 100
+		+ GetAffliction(character, "respiratoryarrest", 0) * 90
+		+ GetAffliction(character, "oxygenlow", 0)
+		+ GetAffliction(character, "hypoxemia", 0)
+		+ GetAffliction(character, "bloodloss", 0)
+		+ GetAffliction(character, "internalbleeding", 0) * 2
+	local functionalBoneScore = PatientFunctionalBoneScore(character)
+	if functionalBoneScore >= 70 then
+		score = score + 18
+	elseif functionalBoneScore > 0 then
+		score = score + 8
+	end
+
+	for _, limbType in ipairs(limbTypes) do
+		local bleeding = GetAfflictionLimb(character, limbType, "bleeding", 0)
+		local nonstop = GetAfflictionLimb(character, limbType, "bleedingnonstop", 0)
+		local bandaged = GetAfflictionLimb(character, limbType, "bandaged", 0)
+		local sutured = GetAfflictionLimb(character, limbType, "suturedw", 0)
+		local dirtyBandage = GetAfflictionLimb(character, limbType, "dirtybandage", 0)
+		local tourniquet = GetAfflictionLimb(character, limbType, "arteriesclamp", 0)
+		local foreignBody = GetAfflictionLimb(character, limbType, "foreignbody", 0)
+		local woundScore = GetAfflictionLimb(character, limbType, "lacerations", 0)
+			+ GetAfflictionLimb(character, limbType, "bitewounds", 0)
+			+ GetAfflictionLimb(character, limbType, "gunshotwound", 0)
+			+ GetAfflictionLimb(character, limbType, "explosiondamage", 0)
+		if bleeding <= 0.1 and nonstop <= 0.1 and (bandaged > 0.1 or sutured > 0.1) then
+			woundScore = 0
+		end
+
+		score = score
+			+ bleeding
+			+ nonstop * 30
+			+ woundScore
+			+ GetAfflictionLimb(character, limbType, "burn", 0)
+			+ Clamp(dirtyBandage - 5, 0, 40)
+			+ Clamp(foreignBody - 5, 0, 45)
+
+		if dirtyBandage >= 10 then score = score + 20 end
+		if foreignBody >= 15 then score = score + 25 end
+		if tourniquet > 0.1 then score = score + 25 end
+
+		if LimbIsExtremity(limbType) then
+			if LimbIsBroken(character, limbType) and GetAfflictionLimb(character, limbType, "gypsumcast", 0) <= 0.1 then
+				score = score + 35
+				if GetAfflictionLimb(character, limbType, "bandaged", 0) >= BI.Settings.fractureBandageThreshold then
+					score = score + 12
+				end
+			end
+			if LimbIsDislocated(character, limbType) then
+				score = score + 28
+			end
+		end
+	end
+
+	return score
+end
+
+local function HasOtherCriticalPatient(helper, selected)
+	if Character == nil or Character.CharacterList == nil then return false end
+
+	for _, patient in pairs(Character.CharacterList) do
+		if patient ~= selected
+			and IsCrewHuman(patient)
+			and patient.TeamID == helper.TeamID
+			and patient ~= helper
+			and IsCriticalPatient(patient)
+			and not IsClaimedByOther(helper, patient)
+		then
+			return true
+		end
+	end
+
+	return false
+end
+
+local function IsHandlingSelectedPatient(helper)
+	local selected = SafeProperty(helper, "SelectedCharacter", nil)
+	if selected == nil or not IsCrewHuman(selected) or selected.TeamID ~= helper.TeamID then
+		BI.State.handling[CharacterKey(helper)] = nil
+		return false
+	end
+
+	local selectedScore = InjuryScore(selected)
+	if selectedScore <= 0.1 then
+		BI.State.handling[CharacterKey(helper)] = nil
+		return false
+	end
+	if IsFollowLocked(selected) then
+		BI.State.handling[CharacterKey(helper)] = nil
+		DeselectCharacter(helper)
+		return false
+	end
+	local canTreatSelected = CanTreat(helper, selected)
+	if not canTreatSelected then
+		BI.State.handling[CharacterKey(helper)] = nil
+		DeselectCharacter(helper)
+		return false
+	end
+
+	ClaimPatient(helper, selected)
+
+	local helperKey = CharacterKey(helper)
+	local state = BI.State.handling[helperKey]
+	if state == nil or state.patient ~= CharacterKey(selected) then
+		state = { patient = CharacterKey(selected), ticks = 0 }
+		BI.State.handling[helperKey] = state
+	end
+
+	if not IsCriticalPatient(selected) and HasOtherCriticalPatient(helper, selected) then
+		BI.State.handling[helperKey] = nil
+		return false
+	end
+
+	if IsCriticalPatient(selected) then
+		if IsMedicalJob(helper)
+			or MedicalSkill(helper) >= BI.Settings.highMedicalSkill
+			or GetAffliction(selected, "cpr_buff", 0) > 0.1
+			or GetAffliction(selected, "cpr_fracturebuff", 0) > 0.1
+			or (NT ~= nil
+				and NT.BotFirstAid ~= nil
+				and NT.BotFirstAid.IsSustainingCPR ~= nil
+				and NT.BotFirstAid.IsSustainingCPR(helper, selected))
+		then
+			state.ticks = 0
+			SetCooldownTicks(CooldownKey(helper, "others"), BI.Settings.criticalRetryCooldownTicks)
+			return true
+		end
+
+		BI.State.handling[helperKey] = nil
+		state.ticks = 0
+		return false
+	end
+
+	state.ticks = 0
+	SetCooldownTicks(CooldownKey(helper, "others"), BI.Settings.cooldownTicks)
+	return true
+end
+
+local function FindBestPatientFor(helper)
+	local bestPatient = nil
+	local bestScore = 0
+	if Character == nil or Character.CharacterList == nil then return nil, 0 end
+
+	for _, patient in pairs(Character.CharacterList) do
+		if IsCrewHuman(patient) and patient.TeamID == helper.TeamID and patient ~= helper and not IsClaimedByOther(helper, patient) then
+			local score = InjuryScore(patient)
+			local canTreat = CanTreat(helper, patient)
+			if canTreat and score > bestScore then
+				bestPatient = patient
+				bestScore = score
+			end
+		end
+	end
+
+	return bestPatient, bestScore
+end
+
+local function HasActiveNonMedicalObjective(character)
+	local ai = SafeProperty(character, "AIController", nil)
+	local manager = ai ~= nil and SafeProperty(ai, "ObjectiveManager", nil) or nil
+	if manager == nil then return false end
+	local ok, result = pcall(function() return manager.HasActiveObjective() end)
+	return ok and result == true
+end
+
+local function AddRescueAll(bot)
+	if NT ~= nil
+		and NT.BotFirstAid ~= nil
+		and NT.BotFirstAid.EnsureSelfCareObjective ~= nil
+		and NT.BotFirstAid.EnsureSelfCareObjective(bot, 1.25)
+	then
+		return true
+	end
+
+	local ai = SafeProperty(bot, "AIController", nil)
+	local manager = ai ~= nil and SafeProperty(ai, "ObjectiveManager", nil) or nil
+	if manager == nil or AIObjectiveRescueAll == nil then return false end
+
+	local ok, objective = pcall(function()
+		return AIObjectiveRescueAll(bot, manager, 1.25)
+	end)
+	if not ok or objective == nil then
+		ok, objective = pcall(function()
+			return AIObjectiveRescueAll.__new(bot, manager, 1.25)
+		end)
+	end
+	if not ok or objective == nil then return false end
+
+	pcall(function()
+		objective.ForceHighestPriority = true
+		objective.OverridePriority = 80
+		objective.SpeakIfFails = false
+	end)
+
+	local added = pcall(function() manager.AddObjective(objective) end)
+	return added == true
+end
+
+local function AddRescueTarget(helper, patient)
+	local ai = SafeProperty(helper, "AIController", nil)
+	local manager = ai ~= nil and SafeProperty(ai, "ObjectiveManager", nil) or nil
+	if manager == nil or AIObjectiveRescue == nil or patient == nil then return false end
+
+	local ok, objective = pcall(function()
+		return AIObjectiveRescue(helper, patient, manager, 1.25)
+	end)
+	if not ok or objective == nil then
+		ok, objective = pcall(function()
+			return AIObjectiveRescue.__new(helper, patient, manager, 1.25)
+		end)
+	end
+	if not ok or objective == nil then return false end
+
+	pcall(function()
+		objective.ForceHighestPriority = true
+		objective.OverridePriority = IsCriticalPatient(patient) and 100 or 85
+		objective.SpeakIfFails = false
+	end)
+
+	local added = pcall(function() manager.AddObjective(objective) end)
+	return added == true
+end
+
+local function ReleaseDeadSelectedTarget(bot)
+	local selected = SafeProperty(bot, "SelectedCharacter", nil)
+	if selected ~= nil and (selected.IsDead or selected.Removed) then
+		pcall(function() bot.DeselectCharacter() end)
+		pcall(function() bot.SelectedCharacter = nil end)
+	end
+end
+
+local function RunInitiative()
+	if Game ~= nil and not Game.RoundStarted then return end
+	if Character == nil or Character.CharacterList == nil then return end
+
+	TickCooldowns()
+
+	for _, bot in pairs(Character.CharacterList) do
+		if IsCrewHuman(bot) and IsBot(bot) then
+			ReleaseDeadSelectedTarget(bot)
+			if IsFetchingMedicalItem(bot) then
+				BI.State.handling[CharacterKey(bot)] = nil
+				SetCooldownTicks(CooldownKey(bot, "others"), BI.Settings.criticalRetryCooldownTicks)
+			else
+				if not IsHandlingSelectedPatient(bot) then
+					local ownScore = InjuryScore(bot)
+					local canSelfTreat, selfMode = CanTreat(bot, bot)
+					if canSelfTreat and selfMode ~= "quick" and ownScore >= BI.Settings.selfCareMinimumScore and not HasCooldown(CooldownKey(bot, "self")) then
+						if AddRescueAll(bot) then SetCooldown(CooldownKey(bot, "self")) end
+					end
+
+					local isMedic = IsMedicalJob(bot)
+					local highSkill = MedicalSkill(bot) >= BI.Settings.highMedicalSkill
+					local policy = GetTreatmentPolicy()
+					local duty = nil
+					if policy ~= nil and policy.GetDutyState ~= nil then
+						pcall(function() duty = policy.GetDutyState(bot) end)
+					end
+					local rescueAssigned = duty ~= nil and duty.rescueDominant == true
+					if (isMedic or highSkill or rescueAssigned) and not HasCooldown(CooldownKey(bot, "others")) then
+						local patient, patientScore = FindBestPatientFor(bot)
+						if patient ~= nil and patientScore >= BI.Settings.criticalScore then
+							local cooldownTicks = IsCriticalPatient(patient) and BI.Settings.criticalRetryCooldownTicks or BI.Settings.cooldownTicks
+							local canTreatPatient = CanTreat(bot, patient)
+							if canTreatPatient and (isMedic or rescueAssigned) then
+								if AddRescueTarget(bot, patient) then
+									ClaimPatient(bot, patient)
+									SetCooldownTicks(CooldownKey(bot, "others"), cooldownTicks)
+								end
+							elseif canTreatPatient and highSkill and (duty == nil or not duty.activeHighFocus) then
+								if AddRescueTarget(bot, patient) then
+									ClaimPatient(bot, patient)
+									SetCooldownTicks(CooldownKey(bot, "others"), cooldownTicks)
+								end
+							end
+						end
+					end
+				end
+			end
+		end
+	end
+end
+
+BI.ThinkCooldown = BI.Settings.intervalTicks
+Hook.Add("think", "NT.BotInitiative.Think", function()
+	BI.ThinkCooldown = BI.ThinkCooldown - 1
+	if BI.ThinkCooldown <= 0 then
+		BI.ThinkCooldown = BI.Settings.intervalTicks
+		pcall(RunInitiative)
+	end
+end)
+
+Hook.Add("roundStart", "NT.BotInitiative.RoundStart", function()
+	BI.State.cooldowns = {}
+	BI.State.claims = {}
+	BI.State.handling = {}
+end)

--- a/Neurotrauma/Lua/Scripts/Server/fuckbots.lua
+++ b/Neurotrauma/Lua/Scripts/Server/fuckbots.lua
@@ -1,28 +1,10 @@
 LuaUserData.MakeMethodAccessible(Descriptors["Barotrauma.HumanAIController"], "SpeakAboutIssues")
 
--- hopefully this stops bots from doing any rescuing at all.
--- and also hopefully my assumption that this very specific thing
--- about bots is what is causing them to eat frames is correct.
-
-if NTConfig.Get("NT_disableBotAlgorithms", true) then
-	Hook.Patch("Barotrauma.AIObjectiveRescueAll", "IsValidTarget", {
-		"Barotrauma.Character",
-		"Barotrauma.Character",
-		"out System.Boolean",
-	}, function(instance, ptable)
-		-- TODO: some bot behavior
-		-- make it hostile act if:
-		-- surgery without corresponding ailments
-		-- treatment without ailments
-
-		-- basic self treatments:
-		-- find items to treat each other for blood loss or bleeding or suturable damage or fractures and dislocations
-		-- ^ would possibly need items to have proper suitable treatments too, and yk bots dont spawn with enough meds...
-
-		ptable.PreventExecution = true
-		return false
-	end, Hook.HookMethodType.Before)
-end
+-- The original Neurotrauma build disabled bot rescue/treatment objectives here.
+-- This modified build keeps vanilla bot rescue/treatment objectives enabled.
+-- Lua/Scripts/Server/botfirstaid.lua only teaches vanilla AI which Neurotrauma
+-- first-aid items fit which afflictions; it does not run a custom triage AI.
+NTConfig.Set("NT_disableBotAlgorithms", false)
 
 local afflictions = {
 	"n_fracture", -- urgent perceivable afflictions
@@ -47,10 +29,6 @@ local afflictions = {
 	"la_fracture",
 	"rl_fracture",
 	"ll_fracture",
-	"dislocation1",
-	"dislocation2",
-	"dislocation3",
-	"dislocation4",
 	"pain_chest", -- not urgent causes
 	"sym_weakness",
 	"sym_sweating",
@@ -86,12 +64,16 @@ Hook.Patch("Barotrauma.HumanAIController", "SpeakAboutIssues", function(instance
 		end
 	end
 
-	for table in NT.SymsForNPC do
-		for identifier in table do
-			if HF.HasAffliction(character, identifier, 1) then
-				message = TextManager.Get("npcdialogsym." .. identifier)
-				character.Speak(message, chatType, math.random(0, 5), Identifier(identifier .. "DialogSym"), 600.0)
-				break
+	-- Extra symptom tables can be registered by other modules. Skip the built-in
+	-- table here because it was already handled above.
+	for key, table in pairs(NT.SymsForNPC) do
+		if key ~= "ntaffs" then
+			for identifier in table do
+				if HF.HasAffliction(character, identifier, 1) then
+					message = TextManager.Get("npcdialogsym." .. identifier)
+					character.Speak(message, chatType, math.random(0, 5), Identifier(identifier .. "DialogSym"), 600.0)
+					break
+				end
 			end
 		end
 	end

--- a/Neurotrauma/Lua/Scripts/Server/humanupdate.lua
+++ b/Neurotrauma/Lua/Scripts/Server/humanupdate.lua
@@ -362,14 +362,10 @@ NT.Afflictions = {
 			if c.afflictions.heartremoved.strength > 0 then c.afflictions[i].strength = 0 end
 		end,
 	},
-	cavityinfection = {
+	infectedperitoneal = {
 		update = function(c, i)
 			if c.afflictions[i].strength > 0 then
-				c.afflictions.immunity.strength = c.afflictions.immunity.strength
-					- NT.Deltatime * (math.min(3, math.min(1, c.afflictions[i].strength / 20)))
-
-				c.afflictions[i].strength = c.afflictions[i].strength
-					+ NT.Deltatime * (2 - 0.0125 * math.max(c.afflictions.immunity.prev, 40))
+				c.afflictions[i].strength = c.afflictions[i].strength + NT.Deltatime * 2
 			end
 		end,
 	},
@@ -1268,7 +1264,6 @@ NT.Afflictions = {
 						or c.afflictions.radiationsickness.strength > 80
 						or (c.afflictions.hemotransfusionshock.strength > 0 and c.afflictions.hemotransfusionshock.strength < 90)
 						or c.stats.withdrawal > 40
-						or c.afflictions.cavityinfection.strength > 5
 					),
 				2
 			)
@@ -1291,7 +1286,7 @@ NT.Afflictions = {
 						NTC.GetSymptom(c.character, i)
 						or c.afflictions.sepsis.strength > 5
 						or c.afflictions.alcoholwithdrawal.strength > 90
-						or c.afflictions.cavityinfection.strength > 5
+						or c.afflictions.infectedperitoneal.strength > 5
 					),
 				2
 			)
@@ -1302,11 +1297,7 @@ NT.Afflictions = {
 			c.afflictions[i].strength = HF.BoolToNum(
 				not NTC.GetSymptomFalse(c.character, i)
 					and c.afflictions.sym_unconsciousness.strength <= 0
-					and (
-						NTC.GetSymptom(c.character, i)
-						or c.afflictions.liverdamage.strength > 65
-						or c.afflictions.cavityinfection.strength > 40
-					),
+					and (NTC.GetSymptom(c.character, i) or c.afflictions.liverdamage.strength > 65),
 				2
 			)
 		end,
@@ -1372,7 +1363,7 @@ NT.Afflictions = {
 						NTC.GetSymptom(c.character, i)
 						or (c.afflictions.hemotransfusionshock.strength > 0 and c.afflictions.hemotransfusionshock.strength < 80)
 						or c.afflictions.t_arterialcut.strength > 0
-						or c.afflictions.cavityinfection.strength > 5
+						or c.afflictions.infectedperitoneal.strength > 5
 					),
 				2
 			)
@@ -1669,7 +1660,7 @@ NT.LimbAfflictions = {
 			-- sepsis
 			local sepsischance = HF.Minimum(limbaff.gangrene.strength, 15, 0) / 400
 				+ HF.Minimum(limbaff.infectedwound.strength, 50) / 1000
-				+ (HF.Minimum(c.afflictions.cavityinfection.strength, 30, 0) / 100) * 2.5
+				+ c.afflictions.infectedperitoneal.strength / 250
 				+ foreignbodycutchance
 			if HF.Chance(sepsischance) then
 				c.afflictions.sepsis.strength = c.afflictions.sepsis.strength + NT.Deltatime

--- a/Neurotrauma/Lua/Scripts/Server/items.lua
+++ b/Neurotrauma/Lua/Scripts/Server/items.lua
@@ -9,14 +9,24 @@ local manuallyCalledItems = {
 	adrenaline = true,
 }
 
+local NTIsBot
+local BotTreatmentMode
+local BotCanUseComplexMedicalEquipment
+
 local function UseItemMethod(item, usingCharacter, targetCharacter, limb, manualCall)
 	-- Invalid use; don't do anything
 	if item == nil or usingCharacter == nil or targetCharacter == nil or limb == nil then return end
+	if NTIsBot ~= nil and BotTreatmentMode ~= nil and NTIsBot(usingCharacter) then
+		local allowed = BotTreatmentMode(usingCharacter, targetCharacter)
+		if not allowed then return end
+		if BotCanUseComplexMedicalEquipment ~= nil and not BotCanUseComplexMedicalEquipment(item, usingCharacter, targetCharacter) then return end
+	end
 
 	if not HF.HasAffliction(targetCharacter, "luabotomy") then HF.SetAffliction(targetCharacter, "luabotomy", 1) end
 
 	-- Get the function associated with the identifier
 	local identifier = item.Prefab.Identifier.Value
+
 	local methodtorun = NT.ItemMethods[identifier]
 
 	if methodtorun ~= nil then
@@ -33,6 +43,60 @@ local function UseItemMethod(item, usingCharacter, targetCharacter, limb, manual
 			return
 		end
 	end
+end
+
+NTIsBot = function(character)
+	if character == nil then return false end
+	local ok, isBot = pcall(function() return character.IsBot end)
+	if ok and isBot ~= nil then return isBot == true end
+	ok, isBot = pcall(function() return character.IsPlayer end)
+	return character.AIController ~= nil and not (ok and isBot == true)
+end
+
+BotTreatmentMode = function(usingCharacter, targetCharacter)
+	if not NTIsBot(usingCharacter) then return true, "player" end
+	if NT == nil or NT.BotEngagementPolicy == nil or NT.BotEngagementPolicy.GetTreatmentMode == nil then return true, "legacy" end
+
+	local ok, allowed, mode = pcall(function()
+		local canTreat, treatmentMode = NT.BotEngagementPolicy.GetTreatmentMode(usingCharacter, targetCharacter)
+		return canTreat, treatmentMode
+	end)
+	if not ok then return true, "legacy_error" end
+	return allowed == true, mode
+end
+
+local complexBotMedicalEquipment = {
+	aed = true,
+	autocpr = true,
+	bvm = true,
+	defibrillator = true,
+}
+
+local function BotIsMedicalJob(character)
+	local ok, isMedic = pcall(function() return character.IsMedic end)
+	if ok and isMedic ~= nil then return isMedic == true end
+
+	local okJob, value = pcall(function()
+		return character.Info.Job.Prefab.Identifier.Value
+	end)
+	if not okJob or value == nil then return false end
+	value = string.lower(tostring(value))
+	return value == "medicaldoctor" or value == "doctor" or value == "medic"
+end
+
+BotCanUseComplexMedicalEquipment = function(item, usingCharacter, targetCharacter)
+	if item == nil or item.Prefab == nil or item.Prefab.Identifier == nil then return true end
+	local identifier = item.Prefab.Identifier.Value
+	if identifier == nil or not complexBotMedicalEquipment[identifier] then return true end
+	if not NTIsBot(usingCharacter) then return true end
+	if usingCharacter == targetCharacter then return false end
+	return BotIsMedicalJob(usingCharacter)
+end
+
+local function BotAllowsAdvancedTreatment(usingCharacter, targetCharacter)
+	if not NTIsBot(usingCharacter) then return true end
+	local allowed, mode = BotTreatmentMode(usingCharacter, targetCharacter)
+	return allowed and mode == "full"
 end
 
 -- TODO: some items trigger afflictions after a single human update, to fix, trigger them immediately for consistency
@@ -504,6 +568,8 @@ end
 -- Gypsum
 NT.ItemMethods.gypsum = function(item, usingCharacter, targetCharacter, limb)
 	local limbtype = HF.NormalizeLimbType(limb.type)
+	local isBotUser = false
+	pcall(function() isBotUser = usingCharacter ~= nil and usingCharacter.IsBot == true end)
 
 	-- Will not work on someone in Stasis
 	if HF.HasAffliction(targetCharacter, "stasis", 0.1) then return end
@@ -513,14 +579,16 @@ NT.ItemMethods.gypsum = function(item, usingCharacter, targetCharacter, limb)
 		and not HF.HasAfflictionLimb(targetCharacter, "gypsumcast", limbtype, 0.1)
 		and not HF.HasAfflictionLimb(targetCharacter, "surgeryincision", limbtype, 1)
 		and HF.LimbIsExtremity(limbtype)
+		and NT.LimbIsBroken(targetCharacter, limbtype)
 	then
-		if HF.GetSkillRequirementMet(usingCharacter, "medical", 40) then
+		if HF.GetSkillRequirementMet(usingCharacter, "medical", 40) or (isBotUser and BotAllowsAdvancedTreatment(usingCharacter, targetCharacter)) then
 			HF.SetAfflictionLimb(targetCharacter, "bandaged", limbtype, 0, usingCharacter)
 			HF.SetAfflictionLimb(targetCharacter, "gypsumcast", limbtype, 100, usingCharacter)
 			NT.BreakLimb(targetCharacter, limbtype, -20)
 			HF.GiveSkillScaled(usingCharacter, "medical", 6000)
 			HF.RemoveItem(item)
 		else
+			if isBotUser then return end
 			HF.RemoveItem(item)
 		end
 	end
@@ -571,9 +639,12 @@ NT.SutureAfflictions = {
 -- Sutures
 NT.ItemMethods.suture = function(item, usingCharacter, targetCharacter, limb)
 	local limbtype = HF.NormalizeLimbType(limb.type)
+	local skillMet = HF.GetSkillRequirementMet(usingCharacter, "medical", 30)
+	local botFallback = not skillMet and NTIsBot(usingCharacter) and BotAllowsAdvancedTreatment(usingCharacter, targetCharacter)
 
-	if HF.GetSkillRequirementMet(usingCharacter, "medical", 30) then
+	if skillMet or botFallback then
 		-- In field use
+		local efficiency = botFallback and 0.45 or 1
 		local healeddamage = 0
 		healeddamage = healeddamage
 			+ HF.Clamp(HF.GetAfflictionStrengthLimb(targetCharacter, limbtype, "lacerations", 0), 0, 20)
@@ -587,12 +658,13 @@ NT.ItemMethods.suture = function(item, usingCharacter, targetCharacter, limb)
 			+ HF.Clamp(HF.GetAfflictionStrengthLimb(targetCharacter, limbtype, "bleeding", 0) / 10, 0, 40)
 		healeddamage = healeddamage
 			+ HF.Clamp(HF.GetAfflictionStrengthLimb(targetCharacter, limbtype, "bleedingnonstop", 0) / 10, 0, 40)
+		healeddamage = healeddamage * efficiency
 
-		HF.AddAfflictionLimb(targetCharacter, "lacerations", limbtype, -20, usingCharacter)
-		HF.AddAfflictionLimb(targetCharacter, "bitewounds", limbtype, -20, usingCharacter)
-		HF.AddAfflictionLimb(targetCharacter, "explosiondamage", limbtype, -20, usingCharacter)
-		HF.AddAfflictionLimb(targetCharacter, "gunshotwound", limbtype, -20, usingCharacter)
-		HF.AddAfflictionLimb(targetCharacter, "bleeding", limbtype, -40, usingCharacter)
+		HF.AddAfflictionLimb(targetCharacter, "lacerations", limbtype, -20 * efficiency, usingCharacter)
+		HF.AddAfflictionLimb(targetCharacter, "bitewounds", limbtype, -20 * efficiency, usingCharacter)
+		HF.AddAfflictionLimb(targetCharacter, "explosiondamage", limbtype, -20 * efficiency, usingCharacter)
+		HF.AddAfflictionLimb(targetCharacter, "gunshotwound", limbtype, -20 * efficiency, usingCharacter)
+		HF.AddAfflictionLimb(targetCharacter, "bleeding", limbtype, -40 * efficiency, usingCharacter)
 		HF.AddAfflictionLimb(targetCharacter, "suturedw", limbtype, healeddamage)
 
 		HF.GiveSkillScaled(usingCharacter, "medical", healeddamage * 100)
@@ -645,6 +717,7 @@ NT.ItemMethods.suture = function(item, usingCharacter, targetCharacter, limb)
 			end
 		end
 	else
+		if NTIsBot(usingCharacter) then return end
 		HF.AddAfflictionLimb(targetCharacter, "internaldamage", limbtype, 6)
 	end
 end

--- a/Neurotrauma/Lua/Scripts/Server/ondamaged.lua
+++ b/Neurotrauma/Lua/Scripts/Server/ondamaged.lua
@@ -168,7 +168,7 @@ NT.OnDamagedMethods.gunshotwound = function(character, strength, limbtype)
 		-- liver and kidney damage
 		if hitOrgan == false and strength >= 2 and HF.Chance(0.5) then
 			HF.AddAfflictionLimb(character, "organdamage", limbtype, strength / 4)
-			HF.AddAffliction(character, "cavityinfection", 5)
+			HF.AddAffliction(character, "infectedperitoneal", 5)
 			if HF.Chance(0.5) then
 				HF.AddAffliction(character, "liverdamage", strength)
 			else

--- a/Neurotrauma/Lua/Scripts/configdata.lua
+++ b/Neurotrauma/Lua/Scripts/configdata.lua
@@ -273,9 +273,9 @@ NT.ConfigData = {
 
 	NT_disableBotAlgorithms = {
 		name = "Disable bot treatment algorithms",
-		default = true,
+		default = false,
 		type = "bool",
-		description = "Prevents bots from attempting to treat afflictions.\nThis is desireable, because bots suck at treating things for the current moment.",
+		description = "Prevents bots from attempting to treat afflictions.\nThis modified Neurotrauma build keeps this disabled and uses a dedicated first-aid triage AI for bots.",
 	},
 
 	NT_screams = {

--- a/Neurotrauma/Lua/Scripts/testing.lua
+++ b/Neurotrauma/Lua/Scripts/testing.lua
@@ -81,6 +81,9 @@ end)
 DebugConsole = LuaUserData.CreateStatic("Barotrauma.DebugConsole")
 
 local function registerDebugCommands()
+	if NT.DebugCommandsRegistered then return end
+	NT.DebugCommandsRegistered = true
+
 	LuaUserData.MakeMethodAccessible(Descriptors["Barotrauma.DebugConsole"], "GetCharacterNames")
 	LuaUserData.MakeMethodAccessible(Descriptors["Barotrauma.DebugConsole"], "FindMatchingCharacter")
 
@@ -105,6 +108,97 @@ local function registerDebugCommands()
 			character = DebugConsole.FindMatchingCharacter({ str })
 		end
 		return character
+	end
+
+	local limbAliases = {
+		leftarm = LimbType.LeftArm,
+		la = LimbType.LeftArm,
+		larm = LimbType.LeftArm,
+		bracoe = LimbType.LeftArm,
+		rightarm = LimbType.RightArm,
+		ra = LimbType.RightArm,
+		rarm = LimbType.RightArm,
+		bracod = LimbType.RightArm,
+		leftleg = LimbType.LeftLeg,
+		ll = LimbType.LeftLeg,
+		lleg = LimbType.LeftLeg,
+		pernae = LimbType.LeftLeg,
+		rightleg = LimbType.RightLeg,
+		rl = LimbType.RightLeg,
+		rleg = LimbType.RightLeg,
+		pernad = LimbType.RightLeg,
+		head = LimbType.Head,
+		cabeca = LimbType.Head,
+		torso = LimbType.Torso,
+	}
+
+	local randomExtremities = {
+		LimbType.LeftArm,
+		LimbType.RightArm,
+		LimbType.LeftLeg,
+		LimbType.RightLeg,
+	}
+
+	local function normalizeText(value)
+		if value == nil then return nil end
+		value = string.lower(tostring(value))
+		value = string.gsub(value, "[áàâã]", "a")
+		value = string.gsub(value, "[éèê]", "e")
+		value = string.gsub(value, "[íìî]", "i")
+		value = string.gsub(value, "[óòôõ]", "o")
+		value = string.gsub(value, "[úùû]", "u")
+		value = string.gsub(value, "ç", "c")
+		return value
+	end
+
+	local function randomFrom(list)
+		return list[math.random(1, #list)]
+	end
+
+	local function resolveTestLimb(value, allowTorsoHead)
+		local key = normalizeText(value)
+		if key == nil or key == "" or key == "random" or key == "any" or key == "qualquer" then
+			return randomFrom(randomExtremities)
+		end
+		if key == "arm" or key == "braco" then return randomFrom({ LimbType.LeftArm, LimbType.RightArm }) end
+		if key == "leg" or key == "perna" then return randomFrom({ LimbType.LeftLeg, LimbType.RightLeg }) end
+
+		local limb = limbAliases[key]
+		if limb == LimbType.Head or limb == LimbType.Torso then
+			return allowTorsoHead and limb or randomFrom(randomExtremities)
+		end
+		return limb or randomFrom(randomExtremities)
+	end
+
+	local function limbLabel(limb)
+		if limb == LimbType.LeftArm then return "braco esquerdo" end
+		if limb == LimbType.RightArm then return "braco direito" end
+		if limb == LimbType.LeftLeg then return "perna esquerda" end
+		if limb == LimbType.RightLeg then return "perna direita" end
+		if limb == LimbType.Head then return "cabeca" end
+		if limb == LimbType.Torso then return "torso" end
+		return "membro desconhecido"
+	end
+
+	local function sendBotTestCommand(command, args)
+		if CLIENT and Game.IsMultiplayer then
+			local limbArg = args[1] or "random"
+			local characterName = args[2]
+			if not characterName or characterName == "" or characterName == "/me" then
+				characterName = Character.Controlled and Character.Controlled.Name or ""
+			end
+			Game.client.SendConsoleCommand(command .. " " .. limbArg .. " " .. '"' .. characterName .. '"')
+			return true
+		end
+		return false
+	end
+
+	local function botTestTarget(args)
+		return findCharacter(args[2])
+	end
+
+	local function printBotTestResult(name, target, limb)
+		print("[NT BotTest] " .. name .. " aplicado em " .. tostring(target.Name) .. " (" .. limbLabel(limb) .. ")")
 	end
 
 	Game.AddCommand(
@@ -302,6 +396,100 @@ local function registerDebugCommands()
 		end,
 		true
 	)
+
+	Game.AddCommand(
+		"nt_bt_fracture",
+		"nt_bt_fracture [random/arm/leg/leftarm/rightarm/leftleg/rightleg] [character name]: breaks an arm or leg for bot first-aid testing",
+		function(args)
+			if sendBotTestCommand("nt_bt_fracture", args) then return end
+
+			local target = botTestTarget(args)
+			if not target then return end
+			local limb = resolveTestLimb(args[1], false)
+			NT.BreakLimb(target, limb, 100)
+			HF.AddAfflictionLimb(target, "blunttrauma", limb, 25, target)
+			HF.AddAfflictionLimb(target, "pain_extremity", limb, 25, target)
+			HF.AddAfflictionLimb(target, "bleeding", limb, 8, target)
+			printBotTestResult("fratura", target, limb)
+		end,
+		function()
+			return { { "random", "arm", "leg", "leftarm", "rightarm", "leftleg", "rightleg" }, DebugConsole.GetCharacterNames() }
+		end,
+		true
+	)
+
+	Game.AddCommand(
+		"nt_bt_artery",
+		"nt_bt_artery [random/arm/leg/leftarm/rightarm/leftleg/rightleg/torso/head] [character name]: cuts an artery for emergency bot testing",
+		function(args)
+			if sendBotTestCommand("nt_bt_artery", args) then return end
+
+			local target = botTestTarget(args)
+			if not target then return end
+			local limb = resolveTestLimb(args[1], true)
+			NT.ArteryCutLimb(target, limb, 25)
+			HF.AddAfflictionLimb(target, "lacerations", limb, 20, target)
+			HF.AddAfflictionLimb(target, "bleeding", limb, 45, target)
+			HF.AddAfflictionLimb(target, "bleedingnonstop", limb, 25, target)
+			HF.AddAffliction(target, "bloodloss", 15, target)
+			printBotTestResult("corte arterial", target, limb)
+		end,
+		function()
+			return { { "random", "arm", "leg", "leftarm", "rightarm", "leftleg", "rightleg", "torso", "head" }, DebugConsole.GetCharacterNames() }
+		end,
+		true
+	)
+
+	Game.AddCommand(
+		"nt_bt_bleed",
+		"nt_bt_bleed [random/arm/leg/leftarm/rightarm/leftleg/rightleg/torso/head] [character name]: creates severe bleeding and a wound for bot testing",
+		function(args)
+			if sendBotTestCommand("nt_bt_bleed", args) then return end
+
+			local target = botTestTarget(args)
+			if not target then return end
+			local limb = resolveTestLimb(args[1], true)
+			HF.AddAfflictionLimb(target, "gunshotwound", limb, 35, target)
+			HF.AddAfflictionLimb(target, "lacerations", limb, 20, target)
+			HF.AddAfflictionLimb(target, "bleeding", limb, 85, target)
+			HF.AddAfflictionLimb(target, "bleedingnonstop", limb, 12, target)
+			HF.AddAffliction(target, "bloodloss", 25, target)
+			printBotTestResult("sangramento grave", target, limb)
+		end,
+		function()
+			return { { "random", "arm", "leg", "leftarm", "rightarm", "leftleg", "rightleg", "torso", "head" }, DebugConsole.GetCharacterNames() }
+		end,
+		true
+	)
+
+	Game.AddCommand(
+		"nt_bt_cardiac",
+		"nt_bt_cardiac [character name]: causes a realistic cardiac arrest test state",
+		function(args)
+			if CLIENT and Game.IsMultiplayer then
+				local characterName = args[1]
+				if not characterName or characterName == "" or characterName == "/me" then
+					characterName = Character.Controlled and Character.Controlled.Name or ""
+				end
+				Game.client.SendConsoleCommand("nt_bt_cardiac " .. '"' .. characterName .. '"')
+				return
+			end
+
+			local target = findCharacter(args[1])
+			if not target then return end
+			HF.SetAffliction(target, "tachycardia", 0, target)
+			HF.SetAffliction(target, "fibrillation", 25, target)
+			HF.SetAffliction(target, "cardiacarrest", 100, target)
+			HF.AddAffliction(target, "oxygenlow", 60, target)
+			HF.AddAffliction(target, "hypoxemia", 45, target)
+			HF.AddAffliction(target, "sym_unconsciousness", 10, target)
+			print("[NT BotTest] parada cardiaca aplicada em " .. tostring(target.Name))
+		end,
+		function()
+			return { DebugConsole.GetCharacterNames() }
+		end,
+		true
+	)
 end
 
 Game.AddCommand("nt_debug", "nt_debug : Enables debug neurotrauma commands", function()
@@ -319,4 +507,4 @@ if CLIENT and Game.IsMultiplayer then Networking.Receive("NT_debug", function(ms
 	registerDebugCommands()
 end) end
 
-if NT.TestingEnabled then registerDebugCommands() end
+registerDebugCommands()

--- a/Neurotrauma/Xml/Afflictions.xml
+++ b/Neurotrauma/Xml/Afflictions.xml
@@ -835,28 +835,6 @@
     <icon texture="%ModDir%/Images/AfflictionIcons2.png" sheetindex="0,5" sheetelementsize="128,128" origin="0,0"/>
   </Affliction>
 
-  <!-- Cavity infection
-  Scanned Symptom, leads to sepsis if severe enough -->
-  <Affliction
-    name=""
-    identifier="cavityinfection"
-    description=""
-    healableinmedicalclinic="false"
-    type="gaze"
-    isbuff="false"
-    targets="human"
-    causeofdeathdescription=""
-    selfcauseofdeathdescription=""
-    limbspecific="false"
-    indicatorlimb="Torso"
-    maxstrength="100"
-    showiconthreshold="500"
-    showinhealthscannerthreshold="20"
-    damageoverlayalpha="0">
-
-    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="128,384,128,128" color="195,136,60,255" origin="0,0"/>
-  </Affliction>
-
   <!-- CPR
   Invisible Status -->
   <Affliction
@@ -3892,28 +3870,6 @@ thats what the vomiting symptom is for -->
       </StatusEffect>
     </Effect>
     <icon texture="%ModDir%/Images/AfflictionIcons.png" sheetindex="5,7" sheetelementsize="128,128" origin="0,0"/>
-  </Affliction>
-
-  <!-- Cleaning cavity -->
-  <Affliction
-    name=""
-    identifier="caviclean"
-    description=""
-    healableinmedicalclinic="true"
-    type="gaze"
-    isbuff="true"
-    limbspecific="true"
-    maxstrength="100"
-    showinhealthscannerthreshold="700"
-    showiconthreshold="1"
-    iconcolors="84,211,211,255;84,211,211,255">
-    <Effect minstrength="0" maxstrength="10" strengthchange="-10">
-      <StatusEffect target="Character" multiplyafflictionsbymaxvitality="true">
-        <ReduceAffliction identifier="cavityinfection" amount="1000"/>
-      </StatusEffect>
-    </Effect>
-    <Effect minstrength="10" maxstrength="100" strengthchange="-10"/>
-    <icon texture="%ModDir%/Images/AfflictionIcons2.png" sheetindex="0,7" sheetelementsize="128,128" origin="0,0"/>
   </Affliction>
 
   <!-- Traumatic Shock / caused by operating w/o table or analgesia

--- a/Neurotrauma/Xml/Items/Consumables.xml
+++ b/Neurotrauma/Xml/Items/Consumables.xml
@@ -25,12 +25,13 @@
 
         <Body width="65" height="45" density="50"/>
 
-        <SuitableTreatment identifier="lacerations" suitability="20"/>
-        <SuitableTreatment identifier="bitewounds" suitability="20"/>
-        <SuitableTreatment identifier="explosiondamage" suitability="20"/>
-        <SuitableTreatment identifier="gunshotwound" suitability="20"/>
-        <SuitableTreatment type="bleeding" suitability="40"/>
-        <SuitableTreatment identifier="surgeryincision" suitability="100"/>
+        <SuitableTreatment identifier="lacerations" suitability="135"/>
+        <SuitableTreatment identifier="bitewounds" suitability="125"/>
+        <SuitableTreatment identifier="explosiondamage" suitability="130"/>
+        <SuitableTreatment identifier="gunshotwound" suitability="140"/>
+        <SuitableTreatment type="bleeding" suitability="35"/>
+        <SuitableTreatment identifier="bleedingnonstop" suitability="110"/>
+        <SuitableTreatment identifier="surgeryincision" suitability="160"/>
 
         <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="5,0" handle1="-5,0" holdangle="10" reload="1.0">
             <StatusEffect type="OnUse" target="This" Condition="-100.0" disabledeltatime="true"/>
@@ -93,6 +94,10 @@
         </Fabricate>
 
         <Deconstruct time="5"/>
+        <SuitableTreatment identifier="ll_fracture" suitability="20"/>
+        <SuitableTreatment identifier="rl_fracture" suitability="20"/>
+        <SuitableTreatment identifier="la_fracture" suitability="20"/>
+        <SuitableTreatment identifier="ra_fracture" suitability="20"/>
 
         <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="64,192,64,64" origin="0.5,0.5"/>
         <Sprite texture="%ModDir%/Images/InGameItemIconAtlas.png" sourcerect="914,250,86,134" depth="0.6" origin="0.5,0.5"/>

--- a/Neurotrauma/Xml/Items/Override.xml
+++ b/Neurotrauma/Xml/Items/Override.xml
@@ -31,10 +31,10 @@
             <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="450,0,64,64" origin="0.5,0.5" />
             <Sprite texture="Content/Items/Tools/tools.png" sourcerect="161,235,64,20" depth="0.55" origin="0.5,0.5" />
             <Body width="60" height="15" density="30" />
-            <SuitableTreatment identifier="dislocation1" suitability="50"/>
-            <SuitableTreatment identifier="dislocation2" suitability="50"/>
-            <SuitableTreatment identifier="dislocation3" suitability="50"/>
-            <SuitableTreatment identifier="dislocation4" suitability="50"/>
+            <SuitableTreatment identifier="dislocation1" suitability="20"/>
+            <SuitableTreatment identifier="dislocation2" suitability="20"/>
+            <SuitableTreatment identifier="dislocation3" suitability="20"/>
+            <SuitableTreatment identifier="dislocation4" suitability="20"/>
 
             <MeleeWeapon slots="Any,RightHand,LeftHand" aimpos="40,5" handle1="-8,0" holdangle="60" reload="1.0" range="50" combatpriority="8" msg="ItemMsgPickUpSelect">
                 <Attack structuredamage="0" itemdamage="2" targetimpulse="5">
@@ -259,7 +259,8 @@
                 <Item identifier="antibloodloss1" copycondition="true" mincondition="0.1"/>
                 <Item identifier="stabilozine" copycondition="true" mincondition="0.1"/>
             </Deconstruct>
-            <SuitableTreatment identifier="bloodloss" suitability="100"/>
+            <!-- Bot patch: keep blood bags for serious bloodloss, below saline/Ringer for routine care. -->
+            <SuitableTreatment identifier="bloodloss" suitability="80"/>
             <InventoryIcon texture="%ModDir%/Images/InventoryItemIconAtlas.png" sourcerect="326,327,64,64" origin="0.5,0.5"/>
             <Sprite texture="%ModDir%/Images/BloodPacksAtlas.png" sourcerect="128,171,64,85" />
             <Body width="80" height="42" density="11"/>
@@ -297,7 +298,16 @@
             </Fabricate>
 
             <Deconstruct time="2"/>
-            <SuitableTreatment type="bleeding" suitability="30" />
+            <SuitableTreatment type="bleeding" suitability="75" />
+            <SuitableTreatment identifier="bleedingnonstop" suitability="20" />
+            <SuitableTreatment identifier="lacerations" suitability="55" />
+            <SuitableTreatment identifier="bitewounds" suitability="45" />
+            <SuitableTreatment identifier="gunshotwound" suitability="55" />
+            <SuitableTreatment identifier="explosiondamage" suitability="45" />
+            <SuitableTreatment identifier="ll_fracture" suitability="75" />
+            <SuitableTreatment identifier="rl_fracture" suitability="75" />
+            <SuitableTreatment identifier="la_fracture" suitability="75" />
+            <SuitableTreatment identifier="ra_fracture" suitability="75" />
             <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="128,448,64,64" origin="0.5,0.5" />
             <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="310,33,26,42" depth="0.6" origin="0.5,0.5" />
             <Body width="25" height="40" density="10.05" />
@@ -333,7 +343,12 @@
             <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="959,771,63,59" origin="0.5,0.5" />
             <Sprite texture="Content/Items/Medical/Medicines.png" sourcerect="340,33,26,42" depth="0.6" origin="0.5,0.5" />
             <Body width="25" height="40" density="10.05" />
-            <SuitableTreatment type="bleeding" suitability="32"/>
+            <SuitableTreatment type="bleeding" suitability="75"/>
+            <SuitableTreatment identifier="bleedingnonstop" suitability="30"/>
+            <SuitableTreatment identifier="lacerations" suitability="70"/>
+            <SuitableTreatment identifier="bitewounds" suitability="60"/>
+            <SuitableTreatment identifier="gunshotwound" suitability="70"/>
+            <SuitableTreatment identifier="explosiondamage" suitability="60"/>
             <SuitableTreatment type="burn" suitability="35"/>
             <SuitableTreatment identifier="infectedwound" suitability="6"/>
             <SuitableTreatment identifier="dirtybandage" suitability="100"/>
@@ -1789,10 +1804,10 @@
             <InventoryIcon texture="Content/Items/JobGear/TalentGear.png" sourcerect="251,1,56,57" origin="0.5,0.5" />
             <Sprite texture="Content/Items/JobGear/TalentGear.png" sourcerect="113,239,57,19" depth="0.55" origin="0.5,0.5" />
             <Body width="60" height="15" density="30" />
-            <SuitableTreatment identifier="dislocation1" suitability="50"/>
-            <SuitableTreatment identifier="dislocation2" suitability="50"/>
-            <SuitableTreatment identifier="dislocation3" suitability="50"/>
-            <SuitableTreatment identifier="dislocation4" suitability="50"/>
+            <SuitableTreatment identifier="dislocation1" suitability="20"/>
+            <SuitableTreatment identifier="dislocation2" suitability="20"/>
+            <SuitableTreatment identifier="dislocation3" suitability="20"/>
+            <SuitableTreatment identifier="dislocation4" suitability="20"/>
             <Holdable slots="Any,RightHand,LeftHand" handle1="0,0" holdangle="60" msg="ItemMsgPickUpSelect">
             </Holdable>
             <aitarget sightrange="500" soundrange="500" fadeouttime="1" />

--- a/Neurotrauma/filelist.xml
+++ b/Neurotrauma/filelist.xml
@@ -66,9 +66,10 @@
   <Other file="%ModDir%/Lua/Scripts/Server/ondamaged.lua" />
 	<Other file="%ModDir%/Lua/Scripts/Shared/surgerytable.lua" />
 	<Other file="%ModDir%/Lua/Scripts/Shared/pronecolliderfix.lua" />
-	<Other file="%ModDir%/Lua/Scripts/Server/lootcrates.lua" />
-	<Other file="%ModDir%/Lua/Scripts/Server/falldamage.lua" />
-	<Other file="%ModDir%/Lua/Scripts/Server/screams.lua" />
+  <Other file="%ModDir%/Lua/Scripts/Server/lootcrates.lua" />
+  <Other file="%ModDir%/Lua/Scripts/Server/falldamage.lua" />
+  <Other file="%ModDir%/Lua/Scripts/Server/screams.lua" />
+  <Other file="%ModDir%/Lua/Scripts/Server/botfirstaid.lua" />
   <Other file="%ModDir%/Lua/Scripts/testing.lua" />
   <Other file="%ModDir%/Lua/Scripts/Server/cpr.lua" />
   <Other file="%ModDir%/Lua/Scripts/Server/ntcompat.lua" />


### PR DESCRIPTION
### Neurotrauma — Bot First Aid AI Update

This update adds AI compatibility with Neurotrauma by allowing bots to perform basic medical tasks and emergency treatment.

## Features

### Basic First Aid

Bots are now able to:

- Apply bandages and sutures.
- Splint and stabilize broken limbs.
- Relocate dislocated bones.
- Administer blood bags.
- Apply medical ointments.
- Perform CPR on unconscious patients.
- And other basic medical procedures.

### Medical Item Retrieval

Bots can search for and retrieve the medical supplies they need to treat themselves or other crew members.

### Self-Treatment

Bots are capable of treating their own injuries when:

- The required treatment is simple.
- No medic is available.
- The situation is critical.

To keep gameplay balanced, bots will generally prioritize their current duties and will not abandon important tasks for minor injuries, only interrupting them when facing severe trauma or life-threatening conditions.

## Limitations

This update focuses exclusively on first aid and emergency care.

Bots are **not capable of performing surgeries or advanced Neurotrauma procedures**.

Complex operations still require player intervention.