### PR TITLE
Remove SurgeryTable container status so we stop getting a million comments about it

### DIFF
--- a/Neurotrauma/Xml/Items/Etc.xml
+++ b/Neurotrauma/Xml/Items/Etc.xml
@@ -29,7 +29,7 @@
 
         <sprite texture="%ModDir%/Images/MedBayAssets.png" sourcerect="100,311,407,184" depth="0.53" premultiplyalpha="false" origin="0.5,0.5"/> 
 
-        <Controller allowingameediting="false" UserPos="0,-300" direction="Right" hidehud="false" canbeselected="true" AllowPuttingInOtherCharacters="true" KickOutCharacterMsg="ItemMsgTakeOutSelectKey" putothercharactermsg="ItemMsgPutInsideSelectKey" SelectingKicksCharacterOut="true" AllowSelectingWhenSelectedByOther="false" selectkey="Select" forceusertostayattached="true">
+        <Controller allowingameediting="false" UserPos="0,-300" direction="Right" hidehud="false" canbeselected="true" selectkey="Select">
             <limbposition limb="Head" position="-6,-10" allowusinglimb="true"/>
             <limbposition limb="Torso" position="104,0" allowusinglimb="true"/>
             <limbposition limb="Waist" position="244,-80" allowusinglimb="true"/>


### PR DESCRIPTION
SurgeryTable allows people to be put into it, at the cost of HealthUI functionality. Remove it so that it returns back to how it was before until the UI problem can be gracefully resolved.